### PR TITLE
Revert back libipl header file rename

### DIFF
--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -53,11 +53,10 @@
 // Headers from pdbg/libipl
 extern "C" {
 #include <libpdbg.h>
-}
-
 #ifdef EDBG_ISTEP_CTRL_FUNCTIONS
-#include <libipl.H>
+#include <libipl.h>
 #endif
+}
 
 // Headers from ecmd-pdbg
 #include <edbgCommon.H>


### PR DESCRIPTION
Reverting back the changes as the libipl changes to rename the
header files are in review and is going to take time to get to merge.

Will push back the original patch after libipl changes are merged.