### PR TITLE
ecmd submodule update and python3 enablement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,7 +70,7 @@ conf.set('__SANE_USERSPACE_TYPES__', true)
 #dependency check
 git     = find_program('git', required : true)
 perl    = find_program('perl', required : true)
-python  = find_program('python', required : true)
+python  = find_program('python3', required : true)
 libcpp  = meson.get_compiler('cpp').find_library('stdc++')
 libz    = meson.get_compiler('cpp').find_library('z')
 libdl   = meson.get_compiler('cpp').find_library('dl')


### PR DESCRIPTION
1) Updated to latest ecmd code to pickup all the updates including python3 updates in ecmd.
2) Move from python to python3 environment in makeext.py
3) Moving from python to python3 in meson build for ecmd-pdbg