### PR TITLE
P9 scom refactor

### DIFF
--- a/bin/edbgBmcWrapper.sh
+++ b/bin/edbgBmcWrapper.sh
@@ -4,24 +4,6 @@
 # help files will be searched under $EDBG_HOME/help/
 # ***************************************************************************
 export EDBG_HOME=/usr/
-PLAT_DTB_DIR=/etc/pdata
-
-#Set default environment value to none
-EDBG_DTB=none
-
-if [ -n "$PDBG_DTB" ] ; then
-	EDBG_DTB="$PDBG_DTB"
-else
-	for entry in "$PLAT_DTB_DIR"/*.dtb ; do
-		if [ -f "$entry" ] ; then
-			EDBG_DTB="$entry"
-		else
-			echo "No DTB files found in the path"
-			exit 1
-		fi
-	done
-fi
-export EDBG_DTB
 
 # ***************************************************************************
 # Execute the edbg using relative path

--- a/bin/updatemodel
+++ b/bin/updatemodel
@@ -31,7 +31,7 @@ then
 fi
 
 # Set env var edbg expects
-export EDBG_DTB=none
+export PDBG_DTB=none
 
 # Call the underlying VPD keyword modification
 echo "Updating system model number to $1"

--- a/bin/updateserial
+++ b/bin/updateserial
@@ -31,7 +31,7 @@ then
 fi
 
 # Set env var edbg expects
-export EDBG_DTB=none
+export PDBG_DTB=none
 
 # Call the underlying VPD keyword modification
 echo "Updating system serial number to $1"

--- a/makefile
+++ b/makefile
@@ -78,6 +78,7 @@ INCLUDES_DLL += edbgReturnCodes.H
 INCLUDES_DLL += lhtVpd.H
 INCLUDES_DLL += lhtVpdFile.H
 INCLUDES_DLL += lhtVpdDevice.H
+INCLUDES_DLL += p9_edbgEcmdDllScom.H
 ifeq (${EDBG_ISTEP_CONTROL}, yes)
     INCLUDES_DLL += edbgIstep.H
 endif
@@ -86,6 +87,7 @@ endif
 INCLUDES := ${INCLUDES_EXE} ${INCLUDES_DLL}
 
 # edbg source files to pull into the build
+SOURCES_DLL += p9_edbgEcmdDllScom.C
 SOURCES_DLL += edbgEcmdDll.C
 SOURCES_DLL += edbgEcmdDllInfo.C
 SOURCES_DLL += edbgOutput.C

--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -50,7 +50,7 @@
 #include <edbgIstep.H>
 #endif
 
-// Headers from pdbg/libipl
+// Headers from pdbg/libipl/libekb
 extern "C" {
 #include <libpdbg.h>
 }
@@ -64,7 +64,7 @@ extern "C" {
 #include <edbgOutput.H>
 #include <lhtVpdFile.H>
 #include <lhtVpdDevice.H>
-#include <p9_scominfo.H>
+#include <p9_edbgEcmdDllScom.H>
 
 // TODO: This needs to not be hardcoded and set from the command-line.
 std::string DEVICE_TREE_FILE;
@@ -82,9 +82,6 @@ uint32_t queryConfigExistSlots(const ecmdChipTarget & i_target, std::list<ecmdSl
 uint32_t queryConfigExistChips(const ecmdChipTarget & i_target, std::list<ecmdChipData> & o_chipData, ecmdQueryDetail_t i_detail, bool i_allowDisabled);
 uint32_t queryConfigExistChipUnits(const ecmdChipTarget & i_target, struct pdbg_target * i_pTarget, std::list<ecmdChipUnitData> & o_chipUnitData, ecmdQueryDetail_t i_detail, bool i_allowDisabled);
 uint32_t queryConfigExistThreads(const ecmdChipTarget & i_target, struct pdbg_target * i_pTarget, std::list<ecmdThreadData> & o_threadData, ecmdQueryDetail_t i_detail, bool i_allowDisabled);
-
-// Used to translate an ecmdChipTarget to a pdbg target
-uint32_t fetchPdbgTarget(const ecmdChipTarget & i_target, struct pdbg_target * o_pdbgTarget);
 
 std::string gEDBG_HOME;
 
@@ -132,60 +129,6 @@ static uint32_t fetchCfamTarget(const ecmdChipTarget & i_target, struct pdbg_tar
   return 0;
 }
 
-/* Given a target in i_target this will return the associcated pdbg target that
- * can be passed to pib_read/write() such that full address translation is
- * performed. For example - getscom pu.ex -c6 20000100 would get translated to
- * pib_read(pdbg_target, 0x100) which would get translated by pib_read() to
- * 0x26000100. */
-static uint32_t fetchPdbgTarget(const ecmdChipTarget & i_target, struct pdbg_target ** o_pdbgTarget) {
-  uint32_t rc = ECMD_SUCCESS;
-  struct pdbg_target *chipTarget, *target;
-  uint32_t index;
-
-  assert(i_target.cageState == ECMD_TARGET_FIELD_VALID &&       \
-         i_target.cage == 0 &&                                  \
-         i_target.nodeState == ECMD_TARGET_FIELD_VALID &&       \
-         i_target.node == 0 &&                                  \
-         i_target.slotState == ECMD_TARGET_FIELD_VALID &&       \
-         i_target.slot == 0 &&                                  \
-         i_target.posState == ECMD_TARGET_FIELD_VALID);
-
-  *o_pdbgTarget = NULL;
-  pdbg_for_each_class_target("pib", chipTarget) {
-    const char *p;
-
-    // Don't search for targets not matched to our index/position
-    index = pdbg_target_index(chipTarget);
-    if (i_target.pos != index)
-      continue;
-
-    // Just return the raw pib target if we're not looking for a specific chip unit
-    if (i_target.chipUnitTypeState == ECMD_TARGET_FIELD_UNUSED) {
-      *o_pdbgTarget = chipTarget;
-    } else {
-      // Search child nodes of this position to find what we are
-      // looking for
-      pdbg_for_each_child_target(chipTarget, target) {
-	p = (char *) pdbg_get_target_property(target, "ecmd,chip-unit-type", NULL);
-        if (p &&
-            p == i_target.chipUnitType &&
-            pdbg_target_index(target) == i_target.chipUnitNum) {
-          *o_pdbgTarget = target;
-	  break;
-        }
-      }
-    }
-
-    if (*o_pdbgTarget)
-      break;
-  }
-
-  if (!*o_pdbgTarget) {
-    return out.error(1, FUNCNAME, "Unable to find pdbg target!\n");
-  }
-
-  return rc;
-}
 
 /* Given a target and a target base address return the chip unit type (eg. "ex",
  * "mba", etc.) */
@@ -216,107 +159,20 @@ static uint32_t findChipUnitType(const ecmdChipTarget &i_target, uint64_t i_addr
   return -1;
 }
 
-//convert the enum to string for use in code
-uint32_t p9n_convertCUEnum_to_String(p9ChipUnits_t i_P9CU, std::string &o_chipUnitType) {
-  uint32_t rc = ECMD_SUCCESS;
-
-  if (i_P9CU == PU_C_CHIPUNIT)            o_chipUnitType = "c";
-  else if (i_P9CU == PU_EQ_CHIPUNIT)      o_chipUnitType = "eq";
-  else if (i_P9CU == PU_EX_CHIPUNIT)      o_chipUnitType = "ex";
-  else if (i_P9CU == PU_XBUS_CHIPUNIT)    o_chipUnitType = "xbus";
-  else if (i_P9CU == PU_OBUS_CHIPUNIT)    o_chipUnitType = "obus";
-  else if (i_P9CU == PU_NV_CHIPUNIT)      o_chipUnitType = "nv";
-  else if (i_P9CU == PU_PEC_CHIPUNIT)     o_chipUnitType = "pec";
-  else if (i_P9CU == PU_PHB_CHIPUNIT)     o_chipUnitType = "phb";
-  else if (i_P9CU == PU_MI_CHIPUNIT)      o_chipUnitType = "mi";
-  else if (i_P9CU == PU_DMI_CHIPUNIT)     o_chipUnitType = "dmi";
-  else if (i_P9CU == PU_MCS_CHIPUNIT)     o_chipUnitType = "mcs";
-  else if (i_P9CU == PU_MCA_CHIPUNIT)     o_chipUnitType = "mca";
-  else if (i_P9CU == PU_MCBIST_CHIPUNIT)  o_chipUnitType = "mcbist";
-  else if (i_P9CU == PU_PERV_CHIPUNIT)    o_chipUnitType = "perv";
-  else if (i_P9CU == PU_PPE_CHIPUNIT)     o_chipUnitType = "ppe";
-  else if (i_P9CU == PU_SBE_CHIPUNIT)     o_chipUnitType = "sbe";
-  else if (i_P9CU == PU_CAPP_CHIPUNIT)    o_chipUnitType = "capp";
-  else if (i_P9CU == PU_MC_CHIPUNIT)      o_chipUnitType = "mc";
-  else {
-    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit enum:%d\n", i_P9CU);
-  }
-
-  return rc;
-}
-
-//convert chipunit string to enum, as scominfo does not accept strings
-uint32_t p9n_convertCUString_to_enum(std::string cuString, p9ChipUnits_t &o_P9CU) {
-  uint32_t rc = ECMD_SUCCESS;
-
-  if (cuString == "c")          o_P9CU = PU_C_CHIPUNIT;
-  else if (cuString == "eq")    o_P9CU = PU_EQ_CHIPUNIT;
-  else if (cuString == "ex")    o_P9CU = PU_EX_CHIPUNIT;
-  else if (cuString == "xbus")  o_P9CU = PU_XBUS_CHIPUNIT;
-  else if (cuString == "obus")  o_P9CU = PU_OBUS_CHIPUNIT;
-  else if (cuString == "nv")    o_P9CU = PU_NV_CHIPUNIT;
-  else if (cuString == "pec")   o_P9CU = PU_PEC_CHIPUNIT;
-  else if (cuString == "phb")   o_P9CU = PU_PHB_CHIPUNIT;
-  else if (cuString == "mi")    o_P9CU = PU_MI_CHIPUNIT;
-  else if (cuString == "dmi")   o_P9CU = PU_DMI_CHIPUNIT;
-  else if (cuString == "mcs")   o_P9CU = PU_MCS_CHIPUNIT;
-  else if (cuString == "mca")   o_P9CU = PU_MCA_CHIPUNIT;
-  else if (cuString == "mcbist")  o_P9CU = PU_MCBIST_CHIPUNIT;
-  else if (cuString == "perv")  o_P9CU = PU_PERV_CHIPUNIT;
-  else if (cuString == "ppe")   o_P9CU = PU_PPE_CHIPUNIT;
-  else if (cuString == "sbe")   o_P9CU = PU_SBE_CHIPUNIT;
-  else if (cuString == "capp")  o_P9CU = PU_CAPP_CHIPUNIT;
-  else if (cuString == "mc")    o_P9CU = PU_MC_CHIPUNIT;
-  else {
-    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit:%S\n", cuString.c_str());
-  }
-
-  return rc;
-}
-
 // Load the device tree and initialise the targets
 static int initTargets(void) {
-  int fd;
-  void *fdt;
-  struct stat stat;
-  static int done = 0;
 
-  if (!done) {
-    done = 1;
-
-    // The user sets their device tree via this variable. If not set, fail
-    // Would be nice to also set via --device on the cmdline, but currently
-    // there is an order of operations problem.
-    // Longer term libpdbg will be able to auto-detect the correct thing to use.
-    char * devTree = getenv("EDBG_DTB");
-    if (devTree == NULL) {
-      return out.error(ECMD_UNKNOWN_FILE, FUNCNAME, "EDBG_DTB not set in environment, you must set it\n");
-    }
-
-    // If set to 'none', skip the rest of what we do to setup the device tree
-    // This is assuming we won't be using any functions that use the device tree
-    if (!strcmp(devTree, "none")) {
+  // If set to 'none', skip the rest of what we do to setup the device tree
+  // This is assuming we won't be using any functions that use the device tree
+  if (!strcmp(getenv("PDBG_DTB"), "none")) {
       return ECMD_SUCCESS;
-    }
-
-    fd = open(devTree, O_RDONLY);
-    if (fd < 0) {
-      return out.error(ECMD_FAILURE, FUNCNAME, "Unable to open device tree: %s\n", devTree);
-    }
-
-    if (fstat(fd, &stat) < 0) {
-      perror("Unable to read device tree size");
-      return ECMD_FAILURE;
-    }
-
-    fdt = mmap(NULL, stat.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-    if (fdt == MAP_FAILED) {
-      perror("Unable to mmap device tree");
-      return ECMD_FAILURE;
-    }
-
-    pdbg_targets_init(fdt);
   }
+  
+  /*  Device tree can also be specified using PDBG_DTB environment variable
+   *  pointing to system device tree.  If system device tree is specified using
+   *  PDBG_DTB, then it will override the default device tree or the specified
+   *  device tree. NULL to use default which is used pdbg. */
+  pdbg_targets_init(NULL);
 
   return ECMD_SUCCESS;
 }
@@ -873,7 +729,6 @@ uint32_t queryConfigExistChips(const ecmdChipTarget & i_target, std::list<ecmdCh
       rc = queryConfigExistChipUnits(i_target, chipTarget, chipData.chipUnitData, i_detail, i_allowDisabled);
       if (rc) return rc;
     }
-
     // Save what we got from recursing down, or just being happy at this level
     o_chipData.push_back(chipData);
   }
@@ -882,6 +737,7 @@ uint32_t queryConfigExistChips(const ecmdChipTarget & i_target, std::list<ecmdCh
 }
 
 uint32_t queryConfigExistChipUnits(const ecmdChipTarget & i_target, struct pdbg_target * i_pTarget, std::list<ecmdChipUnitData> & o_chipUnitData, ecmdQueryDetail_t i_detail, bool i_allowDisabled)  {
+
   uint32_t rc = ECMD_SUCCESS;
   ecmdChipUnitData chipUnitData;
   struct pdbg_target *target;
@@ -924,7 +780,6 @@ uint32_t queryConfigExistChipUnits(const ecmdChipTarget & i_target, struct pdbg_
 
     o_chipUnitData.push_back(chipUnitData);
   }
-
   return rc;
 }
 
@@ -1074,152 +929,50 @@ uint32_t dllCreateChipUnitScomAddress(const ecmdChipTarget & i_target, uint64_t 
 }
 
 #ifndef ECMD_REMOVE_SCOM_FUNCTIONS
-/* ################################################################# */
-/* Scom Functions - Scom Functions - Scom Functions - Scom Functions */
-/* ################################################################# */
-// i_address is a partially translated address - it will contain a
-// chiplet base address but it's up to us to add in the chiplet number
-// and the rest of the offset. libpdbg expects either a fully translated
-// address or a non-translated address, so we need to remove the partial
-// translation so we can pass the non-translated address.
-static uint64_t getRawScomAddress(const ecmdChipTarget & i_target, uint64_t i_address) {
-  //struct pdbg_target *chipUnitTarget;
-  //
-  //if (!findChipUnitType(i_target, i_address, &chipUnitTarget))
-  //  i_address -= dt_get_address(chipUnitTarget->dn, 0, NULL);
-
-  uint64_t o_address = i_address;
-
-  // Only call the conversion function if the target is for a chipunit
-  if (i_target.chipUnitTypeState == ECMD_TARGET_FIELD_VALID) {
-    p9ChipUnits_t l_P9CU = P9N_CHIP; //default is the chip
-    p9n_convertCUString_to_enum(i_target.chipUnitType, l_P9CU);
-
-    o_address = p9_scominfo_createChipUnitScomAddr(l_P9CU, i_target.chipUnitNum, i_address);
-  }
-
-  return o_address;
-}
-
 uint32_t dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail) {
   uint32_t rc = ECMD_SUCCESS;
-  ecmdScomData sdReturn;
 
-  // Wipe out the data structure provided by the user
-  o_queryData.clear();
+  if (pdbg_get_proc() == PDBG_PROC_P9) {
+      rc = p9_dllQueryScom(i_target, o_queryData, i_address, i_detail);
+  } else {
+     return ECMD_FUNCTION_NOT_SUPPORTED;
+  }
 
-  sdReturn.address = i_address;
-  sdReturn.length = 64;
-  sdReturn.isChipUnitRelated = false;
-  sdReturn.endianMode = ECMD_BIG_ENDIAN;
-
-  //// Need to work out the related chip unit. This amounts to getting the
-  //// chiplet id from i_address and wokring out what name to associate with
-  //// it.
-  //if (!findChipUnitType(i_target, i_address, &chipUnitTarget)) {
-  //  p = dt_find_property(chipUnitTarget->dn, "ecmd,chip-unit-type");
-  //  assert(p);
-  //  sdReturn.isChipUnitRelated = true;
-  //  sdReturn.relatedChipUnit.push_back(p->prop);
-  //}
-
-  // per ben
-  // l_mode 0x00000000 p9n dd10
-  // l_mode 0x00000001 PPE_MODE
-  // l_mode 0x00000002 p9n dd20+
-  // l_mode 0x00000004 p9c dd10
-  // l_mode 0x00000008 p9c dd20+
-  uint32_t l_mode = 0x2; // Force it to p9n dd20+ for now
-
-  std::vector<p9_chipUnitPairing_t> l_chipUnitPairing;
-  rc = p9_scominfo_isChipUnitScom(i_address, sdReturn.isChipUnitRelated, l_chipUnitPairing, l_mode);
   if (rc) {
-    return out.error(rc, FUNCNAME,"Invalid scom addr via scom address lookup via p9_scominfo_isChipUnitScom failed\n");
+      return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "queryscom failed!!");
   }
-
-  //for P9n and all other Pegasus Generation of chips we only have 1 chipUnit per scom addr, the list is for the P9 Generation expansion
-  if (sdReturn.isChipUnitRelated) {
-    std::vector<p9_chipUnitPairing_t>::iterator cuPairingIter = l_chipUnitPairing.begin();
-
-    while(cuPairingIter != l_chipUnitPairing.end()) {
-      std::string l_chipUnitType;
-      rc = p9n_convertCUEnum_to_String(cuPairingIter->chipUnitType, l_chipUnitType);
-      if (rc) return rc;
-      sdReturn.isChipUnitRelated = true;
-      sdReturn.relatedChipUnit.push_back(l_chipUnitType);
-      cuPairingIter++;
-    }
-  }
-
-  o_queryData.push_back(sdReturn);
 
   return rc;
 }
 
 uint32_t dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data) {
   uint32_t rc = ECMD_SUCCESS;
-  uint64_t data;
-  struct pdbg_target *target;
 
-  // Convert the input address to an absolute chip level address
-  i_address = getRawScomAddress(i_target, i_address);
-
-  // Now for the call to pdbg, use just the chip level target so the address
-  // doesn't get translated again down in pdbg
-  // i_target is pass by reference, make a local copy before we modify so we don't break upstream
-  ecmdChipTarget l_target = i_target;
-  l_target.chipUnitTypeState = ECMD_TARGET_FIELD_UNUSED;
-
-  // Get the chip level pdbg target for the call to the pib read
-  if (fetchPdbgTarget(l_target, &target)) {
-    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unable to find PIB target\n");
+  if (pdbg_get_proc() == PDBG_PROC_P9) {
+      rc = p9_dllGetScom(i_target,i_address,o_data);
+  } else {
+     return ECMD_FUNCTION_NOT_SUPPORTED;
   }
 
-  // Make sure the pdbg target probe has been done and get the target state
-  if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
-    return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME, "Target not configured!\n");
-  }
-
-  // Do the read and store the data in the return buffer
-  rc = pib_read(target, i_address, &data);
   if (rc) {
-    return out.error(EDBG_READ_ERROR, FUNCNAME, "pib_read of 0x%" PRIx64 " failed!\n", i_address);
+      return out.error(EDBG_READ_ERROR, FUNCNAME, "getscom failed!!");
   }
-  o_data.setBitLength(64);
-  o_data.setDoubleWord(0, data);
 
   return rc;
 }
 
 uint32_t dllPutScom(const ecmdChipTarget & i_target, uint64_t i_address, const ecmdDataBuffer & i_data) {
   uint32_t rc = ECMD_SUCCESS;
-  struct pdbg_target *target;
 
-  // Convert the input address to an absolute chip level address
-  i_address = getRawScomAddress(i_target, i_address);
-
-  // Now for the call to pdbg, use just the chip level target so the address
-  // doesn't get translated again down in pdbg
-  // i_target is pass by reference, make a local copy before we modify so we don't break upstream
-  ecmdChipTarget l_target = i_target;
-  l_target.chipUnitTypeState = ECMD_TARGET_FIELD_UNUSED;
-
-  // Get the chip level pdbg target for the call to the pib write
-  if (fetchPdbgTarget(l_target, &target)) {
-    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unable to find PIB target\n");
+  if (pdbg_get_proc() == PDBG_PROC_P9) {
+      rc = p9_dllPutScom(i_target,i_address,i_data);
+  } else {
+     return ECMD_FUNCTION_NOT_SUPPORTED;
   }
 
-  // Make sure the pdbg target probe has been done and get the target state
-  if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
-    return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME, "Target not configured!\n");
-  }
-
-  // Write the data to the chip
-  rc = pib_write(target, i_address, i_data.getDoubleWord(0));
   if (rc) {
-    return out.error(EDBG_WRITE_ERROR, FUNCNAME, "pib_write of 0x%" PRIx64 " failed!\n", i_address);
+      return out.error(EDBG_WRITE_ERROR, FUNCNAME, "putscom failed!!");
   }
-
   return rc;
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ libekb = meson.get_compiler('cpp').find_library('ekb')
 
 libedbg = library(
             'edbg',
+            'p9/p9_edbgEcmdDllScom.C',
             'dll/edbgEcmdDll.C',
             'dll/edbgEcmdDllInfo.C',
             'istep/edbgIstep.C',

--- a/src/p9/p9_edbgEcmdDllScom.C
+++ b/src/p9/p9_edbgEcmdDllScom.C
@@ -1,0 +1,311 @@
+//IBM_PROLOG_BEGIN_TAG
+/*
+ * eCMD for pdbg Project
+ *
+ * Copyright 2017,2018 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//IBM_PROLOG_END_TAG
+//--------------------------------------------------------------------
+// Includes
+//--------------------------------------------------------------------
+#include <assert.h>
+
+// Headers from pdbg
+extern "C" {
+#include <libpdbg.h>
+}
+
+// Headers from ecmd-pdbg
+#include <edbgCommon.H>
+#include <edbgOutput.H>
+#include <p9_scominfo.H>
+
+#ifndef ECMD_REMOVE_SCOM_FUNCTIONS
+/* Given a target in i_target this will return the associcated pdbg target that
+ * can be passed to pib_read/write() such that full address translation is
+ * performed. For example - getscom pu.ex -c6 20000100 would get translated to
+ * pib_read(pdbg_target, 0x100) which would get translated by pib_read() to
+ * 0x26000100. */
+static uint32_t fetchPdbgTarget(const ecmdChipTarget & i_target, struct pdbg_target ** o_pdbgTarget) {
+  uint32_t rc = ECMD_SUCCESS;
+  struct pdbg_target *chipTarget, *target;
+  uint32_t index;
+
+  assert(i_target.cageState == ECMD_TARGET_FIELD_VALID &&       \
+         i_target.cage == 0 &&                                  \
+         i_target.nodeState == ECMD_TARGET_FIELD_VALID &&       \
+         i_target.node == 0 &&                                  \
+         i_target.slotState == ECMD_TARGET_FIELD_VALID &&       \
+         i_target.slot == 0 &&                                  \
+         i_target.posState == ECMD_TARGET_FIELD_VALID);
+
+  std::string cuString;
+  
+  *o_pdbgTarget = NULL;
+  pdbg_for_each_class_target("pib", chipTarget) {
+    const char *p;
+
+    // Don't search for targets not matched to our index/position
+    index = pdbg_target_index(chipTarget);
+    if (i_target.pos != index)
+      continue;
+
+    // Just return the raw pib target if we're not looking for a specific chip unit
+    if (i_target.chipUnitTypeState == ECMD_TARGET_FIELD_UNUSED) {
+      *o_pdbgTarget = chipTarget;
+    } else {
+      // Search child nodes of this position to find what we are
+      // looking for
+      pdbg_for_each_child_target(chipTarget, target) {
+	p = (char *) pdbg_get_target_property(target, "ecmd,chip-unit-type", NULL);
+        if (p &&
+            p == i_target.chipUnitType &&
+            pdbg_target_index(target) == i_target.chipUnitNum) {
+          *o_pdbgTarget = target;
+	  break;
+        }
+      }
+    }
+    if (*o_pdbgTarget)
+      break;
+  }
+
+  if (!*o_pdbgTarget) {
+    return out.error(1, FUNCNAME, "Unable to find pdbg target!\n");
+  }
+
+  return rc;
+}
+
+//convert the enum to string for use in code
+uint32_t p9n_convertCUEnum_to_String(p9ChipUnits_t i_P9CU, std::string &o_chipUnitType) {
+  uint32_t rc = ECMD_SUCCESS;
+
+  if (i_P9CU == PU_C_CHIPUNIT)            o_chipUnitType = "c";
+  else if (i_P9CU == PU_EQ_CHIPUNIT)      o_chipUnitType = "eq";
+  else if (i_P9CU == PU_EX_CHIPUNIT)      o_chipUnitType = "ex";
+  else if (i_P9CU == PU_XBUS_CHIPUNIT)    o_chipUnitType = "xbus";
+  else if (i_P9CU == PU_OBUS_CHIPUNIT)    o_chipUnitType = "obus";
+  else if (i_P9CU == PU_NV_CHIPUNIT)      o_chipUnitType = "nv";
+  else if (i_P9CU == PU_PEC_CHIPUNIT)     o_chipUnitType = "pec";
+  else if (i_P9CU == PU_PHB_CHIPUNIT)     o_chipUnitType = "phb";
+  else if (i_P9CU == PU_MI_CHIPUNIT)      o_chipUnitType = "mi";
+  else if (i_P9CU == PU_DMI_CHIPUNIT)     o_chipUnitType = "dmi";
+  else if (i_P9CU == PU_MCS_CHIPUNIT)     o_chipUnitType = "mcs";
+  else if (i_P9CU == PU_MCA_CHIPUNIT)     o_chipUnitType = "mca";
+  else if (i_P9CU == PU_MCBIST_CHIPUNIT)  o_chipUnitType = "mcbist";
+  else if (i_P9CU == PU_PERV_CHIPUNIT)    o_chipUnitType = "perv";
+  else if (i_P9CU == PU_PPE_CHIPUNIT)     o_chipUnitType = "ppe";
+  else if (i_P9CU == PU_SBE_CHIPUNIT)     o_chipUnitType = "sbe";
+  else if (i_P9CU == PU_CAPP_CHIPUNIT)    o_chipUnitType = "capp";
+  else if (i_P9CU == PU_MC_CHIPUNIT)      o_chipUnitType = "mc";
+  else {
+    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit enum:%d\n", i_P9CU);
+  }
+
+  return rc;
+}
+
+//convert chipunit string to enum, as scominfo does not accept strings
+uint32_t p9n_convertCUString_to_enum(std::string cuString, p9ChipUnits_t &o_P9CU) {
+  uint32_t rc = ECMD_SUCCESS;
+
+  if (cuString == "c")          o_P9CU = PU_C_CHIPUNIT;
+  else if (cuString == "eq")    o_P9CU = PU_EQ_CHIPUNIT;
+  else if (cuString == "ex")    o_P9CU = PU_EX_CHIPUNIT;
+  else if (cuString == "xbus")  o_P9CU = PU_XBUS_CHIPUNIT;
+  else if (cuString == "obus")  o_P9CU = PU_OBUS_CHIPUNIT;
+  else if (cuString == "nv")    o_P9CU = PU_NV_CHIPUNIT;
+  else if (cuString == "pec")   o_P9CU = PU_PEC_CHIPUNIT;
+  else if (cuString == "phb")   o_P9CU = PU_PHB_CHIPUNIT;
+  else if (cuString == "mi")    o_P9CU = PU_MI_CHIPUNIT;
+  else if (cuString == "dmi")   o_P9CU = PU_DMI_CHIPUNIT;
+  else if (cuString == "mcs")   o_P9CU = PU_MCS_CHIPUNIT;
+  else if (cuString == "mca")   o_P9CU = PU_MCA_CHIPUNIT;
+  else if (cuString == "mcbist")  o_P9CU = PU_MCBIST_CHIPUNIT;
+  else if (cuString == "perv")  o_P9CU = PU_PERV_CHIPUNIT;
+  else if (cuString == "ppe")   o_P9CU = PU_PPE_CHIPUNIT;
+  else if (cuString == "sbe")   o_P9CU = PU_SBE_CHIPUNIT;
+  else if (cuString == "capp")  o_P9CU = PU_CAPP_CHIPUNIT;
+  else if (cuString == "mc")    o_P9CU = PU_MC_CHIPUNIT;
+  else {
+    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit:%S\n", cuString.c_str());
+  }
+
+  return rc;
+}
+
+/* ################################################################# */
+/* Scom Functions - Scom Functions - Scom Functions - Scom Functions */
+/* ################################################################# */
+// i_address is a partially translated address - it will contain a
+// chiplet base address but it's up to us to add in the chiplet number
+// and the rest of the offset. libpdbg expects either a fully translated
+// address or a non-translated address, so we need to remove the partial
+// translation so we can pass the non-translated address.
+static uint64_t getRawScomAddress(const ecmdChipTarget & i_target, uint64_t i_address) {
+ //struct pdbg_target *chipUnitTarget;
+ //
+ //(!findChipUnitType(i_target, i_address, &chipUnitTarget))
+ //  i_address -= dt_get_address(chipUnitTarget->dn, 0, NULL);
+
+  uint64_t o_address = i_address;
+
+  // Only call the conversion function if the target is for a chipunit
+  if (i_target.chipUnitTypeState == ECMD_TARGET_FIELD_VALID) {
+    p9ChipUnits_t l_P9CU = P9N_CHIP; //default is the chip
+    p9n_convertCUString_to_enum(i_target.chipUnitType, l_P9CU);
+
+    o_address = p9_scominfo_createChipUnitScomAddr(l_P9CU, i_target.chipUnitNum, i_address);
+  }
+
+  return o_address;
+}
+
+uint32_t p9_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail) {
+  uint32_t rc = ECMD_SUCCESS;
+  ecmdScomData sdReturn;
+
+  // Wipe out the data structure provided by the user
+  o_queryData.clear();
+
+  sdReturn.address = i_address;
+  sdReturn.length = 64;
+  sdReturn.isChipUnitRelated = false;
+  sdReturn.endianMode = ECMD_BIG_ENDIAN;
+
+  //// Need to work out the related chip unit. This amounts to getting the
+  //// chiplet id from i_address and wokring out what name to associate with
+  //// it.
+  //if (!findChipUnitType(i_target, i_address, &chipUnitTarget)) {
+  //  p = dt_find_property(chipUnitTarget->dn, "ecmd,chip-unit-type");
+  //  assert(p);
+  //  sdReturn.isChipUnitRelated = true;
+  //  sdReturn.relatedChipUnit.push_back(p->prop);
+  //}
+  
+  // per ben
+  // l_mode 0x00000000 p9n dd10
+  // l_mode 0x00000001 PPE_MODE
+  // l_mode 0x00000002 p9n dd20+
+  // l_mode 0x00000004 p9c dd10
+  // l_mode 0x00000008 p9c dd20+
+  uint32_t l_mode = 0x2; // Force it to p9n dd20+ for now
+
+  std::vector<p9_chipUnitPairing_t> l_chipUnitPairing;
+  rc = p9_scominfo_isChipUnitScom(i_address, sdReturn.isChipUnitRelated, l_chipUnitPairing, l_mode);
+  if (rc) {
+    return out.error(rc, FUNCNAME,"Invalid scom addr via scom address lookup via p9_scominfo_isChipUnitScom failed\n");
+  }
+  
+  //for P9n and all other Pegasus Generation of chips we only have 1 chipUnit per scom addr, the list is for the P9 Generation expansion
+  if (sdReturn.isChipUnitRelated) {
+    std::vector<p9_chipUnitPairing_t>::const_iterator cuPairingIter = l_chipUnitPairing.begin();
+
+    while(cuPairingIter != l_chipUnitPairing.end()) {
+      std::string l_chipUnitType;
+      rc = p9n_convertCUEnum_to_String(cuPairingIter->chipUnitType, l_chipUnitType);
+      if (rc) return rc;
+      sdReturn.isChipUnitRelated = true;
+      sdReturn.relatedChipUnit.push_back(l_chipUnitType);
+      sdReturn.relatedChipUnitShort.push_back(l_chipUnitType);
+      cuPairingIter++;
+    }
+  }
+  o_queryData.push_back(sdReturn);
+
+  return rc;
+}
+
+uint32_t p9_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data) {
+  uint32_t rc = ECMD_SUCCESS;
+  uint64_t data;
+  struct pdbg_target *target;
+  
+  // Convert the input address to an absolute chip level address
+  i_address = getRawScomAddress(i_target, i_address);
+
+  // Now for the call to pdbg, use just the chip level target so the address
+  // doesn't get translated again down in pdbg
+  // i_target is pass by reference, make a local copy before we modify so we don't break upstream
+  ecmdChipTarget l_target = i_target;
+  l_target.chipUnitTypeState = ECMD_TARGET_FIELD_UNUSED;
+
+  // Get the chip level pdbg target for the call to the pib read
+  if (fetchPdbgTarget(l_target, &target)) {
+    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unable to find PIB target\n");
+  }
+
+  // Make sure the pdbg target probe has been done and get the target state
+  if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+    return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME, "Target not configured!\n");
+  }
+
+  // Do the read and store the data in the return buffer
+  rc = pib_read(target, i_address, &data);
+  if (rc) {
+    return out.error(EDBG_READ_ERROR, FUNCNAME, "pib_read of 0x%" PRIx64 " failed!\n", i_address);
+  }
+  o_data.setBitLength(64);
+  o_data.setDoubleWord(0, data);
+
+  return rc;
+
+}
+
+uint32_t p9_dllPutScom(const ecmdChipTarget & i_target, uint64_t i_address, const ecmdDataBuffer & i_data) {
+  uint32_t rc = ECMD_SUCCESS;
+  struct pdbg_target *target;
+  
+  // Convert the input address to an absolute chip level address
+  i_address = getRawScomAddress(i_target, i_address);
+
+  // Now for the call to pdbg, use just the chip level target so the address
+  // doesn't get translated again down in pdbg
+  // i_target is pass by reference, make a local copy before we modify so we don't break upstream
+  ecmdChipTarget l_target = i_target;
+  l_target.chipUnitTypeState = ECMD_TARGET_FIELD_UNUSED;  
+
+  // Get the chip level pdbg target for the call to the pib read
+  if (fetchPdbgTarget(l_target, &target)) {
+    return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unable to find PIB target\n");
+  }
+
+  // Make sure the pdbg target probe has been done and get the target state
+  if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+    return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME, "Target not configured!\n");
+  }
+  
+  // Write the data to the chip
+  rc = pib_write(target, i_address, i_data.getDoubleWord(0));
+  if (rc) {
+    return out.error(EDBG_WRITE_ERROR, FUNCNAME, "pib_write of 0x%" PRIx64 " failed!\n", i_address);
+  }
+
+  return rc;
+}
+
+uint32_t p9_dllPutScomUnderMask(const ecmdChipTarget & i_target, uint64_t i_address, const ecmdDataBuffer & i_data, const ecmdDataBuffer & i_mask) {
+  return ECMD_FUNCTION_NOT_SUPPORTED;
+}
+
+uint32_t p9_dllDoScomMultiple(const ecmdChipTarget & i_target, std::list<ecmdScomEntry> & io_entries) {
+  return ECMD_FUNCTION_NOT_SUPPORTED;
+}
+#endif // ECMD_REMOVE_SCOM_FUNCTIONS
+
+
+

--- a/src/p9/p9_edbgEcmdDllScom.H
+++ b/src/p9/p9_edbgEcmdDllScom.H
@@ -1,0 +1,30 @@
+//IBM_PROLOG_BEGIN_TAG
+/* 
+ * eCMD for pdbg Project
+ *
+ * Copyright 2017,2018 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//IBM_PROLOG_END_TAG
+#ifndef p9_edbgEcmdDllScom_H
+#define p9_edbgEcmdDllScom_H
+
+uint32_t p9_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail);
+
+uint32_t p9_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data);
+
+uint32_t p9_dllPutScom(const ecmdChipTarget & i_target, uint64_t i_address, const ecmdDataBuffer & i_data);
+
+#endif


### PR DESCRIPTION
 1. pdbg submodule update to the latest upstream SHA
 2. p9 scom refactor to support multiple platforms at runtime
 3. Refactor initTargets() and other places referencing EDBG_DTB to move to PDBG_DTB
