### PR TITLE
Remove checking of env variable PDBG_DTB 

### DIFF
--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -222,12 +222,6 @@ void setPhalLogLevel()
 // Load the device tree and initialise the targets
 static int initTargets(void) {
 
-  // If set to 'none', skip the rest of what we do to setup the device tree
-  // This is assuming we won't be using any functions that use the device tree
-  if (!strcmp(getenv("PDBG_DTB"), "none")) {
-      return ECMD_SUCCESS;
-  }
-
   // set pdbg loglvel
   pdbg_set_loglevel(getLogLevelFromEnv("PDBG_LOG", PDBG_ERROR));
 


### PR DESCRIPTION
Remove checking of env variable PDBG_DTB and use default pdbg backend device tree if not set

PDBG code now default uses backend device tree if the device tree path is not set in the environment variable . So, checking the ENV variable is not required

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>