### PR TITLE
Set the host state to running if istep is 6.4

### DIFF
--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -2038,6 +2038,12 @@ uint32_t iStepsHelper(uint16_t i_major_start,
               rc = ipl_run_major_minor(major_istep, minor_istep);
               if (!rc)
               {
+                  if (major_istep == 6 && minor_istep == 4) {
+                     //if the istep reaches above 6.4  then, set the Host state to running!
+                     rc = g_edbgIPLTable.setHostStateToRunning();
+                     if (rc != ECMD_SUCCESS)
+                         return out.error(rc, FUNCNAME, "FAIL: failed to set host state\n");
+                  } 
                   out.print("PASS: istep %s\n",IStepName.c_str());
 	      }
               else
@@ -2120,6 +2126,12 @@ uint32_t iStepsHelper(uint16_t i_major,
             rc = ipl_run_major_minor(i_major, istep);
             if (!rc)
             {
+                if (i_major == 6 && istep == 4) {
+                    //if the istep reaches 6.4 then, set the Host state to running!
+                    rc = g_edbgIPLTable.setHostStateToRunning();
+                    if (rc != ECMD_SUCCESS)
+                        return out.error(rc, FUNCNAME, "FAIL: failed to set host state\n");
+                } 
                 out.print("PASS: istep %s\n",IStepName.c_str());
 	    }
             else
@@ -2325,6 +2337,12 @@ uint32_t dllIStepsByName(std::string i_stepName) {
         rc = ipl_run_major_minor(o_majorNum, o_minorNum);
         if (!rc)
         {
+            if (o_majorNum == 6 && o_minorNum == 4) {
+                //if the istep reaches 6.4 then, set the Host state to running!
+                rc = g_edbgIPLTable.setHostStateToRunning();
+                if (rc != ECMD_SUCCESS)
+                    return out.error(rc, FUNCNAME, "FAIL: failed to set host state\n");
+            } 
             out.print("PASS: istep %s\n",i_stepName.c_str());
         }
         else

--- a/src/istep/edbgIstep.C
+++ b/src/istep/edbgIstep.C
@@ -710,5 +710,26 @@ int edbgIPLTable::istepPowerOn()
     return rc;
 }
 
-
+//Set host state to running
+///////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////
+int edbgIPLTable::setHostStateToRunning()
+{
+    int rc = ECMD_SUCCESS;
+    std::string set_host_state_cmd = "busctl set-property" \
+                                     " xyz.openbmc_project.State.Host" \
+                                     " /xyz/openbmc_project/state/host0" \ 
+                                     " xyz.openbmc_project.State.Host" \
+                                     " CurrentHostState s" \
+                                     " xyz.openbmc_project.State.Host.HostState.Running";
+    
+    //Set host state to running if condition is met
+    rc = system(set_host_state_cmd.c_str());
+    if (rc != 0)
+    {
+        rc = -errno;
+        return rc;
+    }
+    return rc;
+}
 

--- a/src/istep/edbgIstep.H
+++ b/src/istep/edbgIstep.H
@@ -328,6 +328,22 @@ public:
    */
 
   int startAttnHandler();
+   
+  ///////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////
+  /**
+   * @brief Set the host state to running
+   *
+   * @par Description:
+   *     This routine sets the host state to running
+   *     
+   *
+   * @return errno as return code on failure else ECMD_SUCCESS
+   * 
+   */
+  
+  int setHostStateToRunning();
+  
 private:
 
     // Disabled copy constructor and assignment operator


### PR DESCRIPTION
Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>

This PR takes care of doing following

istep has limitation currently of that the BMC tracking of host state is not correct
(due to istep running outside of the bounds of state management on the BMC)

This PR  will take care of setting the Host state to running when istep 6.4 is reached