### PR TITLE
Fix null byte messages

### DIFF
--- a/bin/edbgdetcnfg
+++ b/bin/edbgdetcnfg
@@ -16,7 +16,7 @@ echo "vpd:" >> $EDBG_CNFG
 # yet in use, so no detremental effects
 for i in `ls /sys/bus/i2c/devices/*/of_node/label`
 do 
-  if [ `cat $i` = "system-vpd" ]
+  if [ $(tr -d '\0' < $i) = "system-vpd" ]
   then 
     echo "  - target: k0:n0:s0" >> $EDBG_CNFG
     echo "    system-vpd: "`dirname \`dirname $i\``"/eeprom" >> $EDBG_CNFG

--- a/makefile
+++ b/makefile
@@ -307,9 +307,9 @@ ${OBJS_EXE} ${OBJS_DLL} ${OBJS_ALL}: ${OBJPATH}%.o : %.C ${INCLUDES} | dir date
 # *****************************************************************************
 # Create the Target
 # *****************************************************************************
-LINK_LIBS := -L${PDBG_ROOT}/.libs -lpdbg -lfdt -lz -lyaml -lstdc++fs
+LINK_LIBS := -L${PDBG_ROOT}/.libs -lpdbg -lfdt -lz -lyaml
 ifeq (${EDBG_ISTEP_CONTROL}, yes)
-    LINK_LIBS += -lipl -lekb
+    LINK_LIBS += -lipl -lekb -lstdc++fs
 endif
 
 ${TARGET_EXE}: ${OBJS_DLL} ${OBJS_EXE} ${OBJS_ALL}

--- a/src/p10/p10_edbgEcmdDllScom.C
+++ b/src/p10/p10_edbgEcmdDllScom.C
@@ -241,7 +241,7 @@ uint32_t p10_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecm
   else  //Not a valid target is passed
   {
       return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Not a valid target passed %s \n",
-                       i_target.chipType);
+                       i_target.chipType.c_str());
   }
 
   o_data.setBitLength(64);
@@ -319,7 +319,7 @@ uint32_t p10_dllPutScom(const ecmdChipTarget & i_target, uint64_t i_address, con
   else  //Not a valid target is passed
   {
       return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Not a valid target passed %s \n",
-                       i_target.chipType);
+                       i_target.chipType.c_str());
   }
   return rc;
 }


### PR DESCRIPTION
Newer version of bash don't like using cat to read the eeprom label value and generate warning messages.  The update removes those warnings and doesn't change function.

Also included are compile issue fixes encountered when trying to package this update.