### PR TITLE
Add support to log traces into journal

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -306,5 +306,8 @@ foreach helptext : ['cipinstruct.htxt', 'cipgetmemproc.htxt', 'cipputmemproc.htx
       install_dir : helpdir)
 endforeach
 
+conf.set('JOURNAL', get_option('journal').enabled(),
+              description : 'Use journal to log traces'
+             )
 configure_file(output: 'config.h', configuration: conf)
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('rootprefix', type : 'string',
        description : '''override the root prefix [default: '/usr']''')
 option('chip', type : 'combo', choices : ['p10', 'p11'], value : 'p10',
        description: 'Build choice for a chip')
+option('journal', type: 'feature', value : 'disabled',
+        description : '''Enable to get journald support for the log''')       

--- a/src/common/edbgOutput.C
+++ b/src/common/edbgOutput.C
@@ -38,6 +38,12 @@
 #include "ecmdDllCapi.H"  ///< To register errors with the plugin
 #include "ecmdSharedUtils.H"
 
+#include "config.h"
+
+#ifdef JOURNAL
+#include <systemd/sd-journal.h>
+#endif
+
 #undef edbgOutput_C
 
 //----------------------------------------------------------------------
@@ -91,6 +97,9 @@ void edbgOutput::print(bool i_debug, const char* printMsg, va_list &arg_ptr) {
   /* Print to the screen */
   if (printmode == PRINT_UNIX || printmode == PRINT_DOS) {
     vprintf(printMsg, arg_ptr);
+#ifdef JOURNAL    
+    sd_journal_printv(LOG_INFO, printMsg, arg_ptr);
+#endif    
   } else if (printmode == PRINT_NONE) {
     /* Printing has been turned off */
   } else {

--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -195,6 +195,47 @@ static inline uint8_t getLogLevelFromEnv(const char* env, const uint8_t i_logLev
 
 #ifdef EDBG_ISTEP_CTRL_FUNCTIONS
 
+
+/**
+  * @brief This is the method that is registered and will be called
+  *        when the libraries need to add traces 
+  *
+  * @param void*, print format, contents to be printed
+  * @return None
+  */
+void processLogTraceCallback(void*, const char* fmt, va_list ap)
+{
+   out.print(fmt, ap);
+}
+
+/**
+  * @brief This is the method that is registered and will be called
+  *        when the libraries need to add traces 
+  *
+  * @param loglevel (ignoring if provided), 
+  *        print format, contents to be printed
+  * @return None
+  */
+void pDBGLogTraceCallbackHelper(int loglevel, const char* fmt, va_list ap)
+{
+    processLogTraceCallback(nullptr, fmt, ap);
+}
+
+/**
+  * @brief This is helper function to set phal libraries log callback method
+  *        to capture the logs based on the log level set
+  *
+  * @param None
+  * @return None
+  */
+void setLogCallbacks()
+{
+   // add callback for debug traces
+   pdbg_set_logfunc(pDBGLogTraceCallbackHelper);
+   libekb_set_logfunc(processLogTraceCallback, nullptr);
+   ipl_set_logfunc(processLogTraceCallback, nullptr);
+}
+
 /**
   * @brief This is helper function to set phal libraries log level based on
   *        environment varaibles values.
@@ -2002,6 +2043,7 @@ uint32_t iStepsHelper(uint16_t i_major_start,
 
   //Setting phal log level
   setPhalLogLevel();
+  setLogCallbacks();
 
   /* loop through each major & minor isteps */
   /* kick off isteps */
@@ -2121,6 +2163,7 @@ uint32_t iStepsHelper(uint16_t i_major,
 
     //Setting pHAL log level
     setPhalLogLevel();
+    setLogCallbacks();
 
     /* loop through each isteps */
     for (uint16_t istep = i_minor_start; istep <= i_minor_end ; istep++) {
@@ -2333,6 +2376,7 @@ uint32_t dllIStepsByName(std::string i_stepName) {
 
     //Setting pHAL log level
     setPhalLogLevel();
+    setLogCallbacks();
 
     l_start_index = g_edbgIPLTable.getPosition(i_stepName);
     l_destination = g_edbgIPLTable.getDestination(l_start_index);

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,11 +10,16 @@ headers = include_directories('common',
                               '../ecmd/ecmd-core/capi',
                               '../ecmd/ecmd-core/cmd',
                               '../' + autogen_path,
-                              '../ecmd/ecmd-core/ext/cip/capi')
+                              '../ecmd/ecmd-core/ext/cip/capi',
+                              '..')
 
 libpdbg = meson.get_compiler('cpp').find_library('pdbg')
 libipl = meson.get_compiler('cpp').find_library('ipl')
 libekb = meson.get_compiler('cpp').find_library('ekb')
+
+if get_option('journal').enabled()
+    libsystemd_pkg = dependency('libsystemd')
+endif
 
 libedbg = library(
             'edbg',
@@ -39,7 +44,7 @@ libedbg = library(
             '../ecmd/ecmd-core/dll/ecmdDllCapi.C',
             '../' + autogen_path + '/cipDllCapi.C',
             include_directories : headers,
-            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb],
+            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb, get_option('journal').enabled() ? libsystemd_pkg :[]],
             link_with : libecmd,
             version: meson.project_version(),
             install: true)


### PR DESCRIPTION
use case:
When user executes ecmd-pdbg 'istep' command, ecmd-pdbg, ipl traces were not logged into the journal and it is difficult to trace any error.

register callbacks from ipl, pdbg, liekb library and redirect them to terminal and journal (if enabled)

Now with the compile time flag "-Djournal=enabled" the logs will be added to journal and terminal with the LOG_INFO priority. If the compile time flag is NOT provided, then the logs are printed only onto the terminal.

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>