### PR TITLE
Fix CI build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ You can then build with a regular `make` call
 Alternatively ecmd-pdbg can be built using `meson`.
 
 Need `meson` and `ninja`. Alternatively, source an OpenBMC ARM/x86 SDK.
+Before running the meson build the following submodule init and update 
+commands should be executed
+
 ```
+git submodule init
+git submodule update
 meson build && ninja -C build
 ```
 

--- a/meson.build
+++ b/meson.build
@@ -77,21 +77,6 @@ libz    = meson.get_compiler('cpp').find_library('z')
 libdl   = meson.get_compiler('cpp').find_library('dl')
 libyaml = meson.get_compiler('cpp').find_library('yaml')
 
-message('git submodule init & update of ecmd')
-rc = run_command(git, 'submodule', 'init', 'ecmd')
-if rc.returncode() != 0
-  error('git submodule init of ecmd : FAILED')
-endif
-
-message('git submodule init of ecmd : SUCCESS')
-
-rc = run_command(git, 'submodule', 'update', 'ecmd')
-if rc.returncode() != 0
-  error('git submodule update of ecmd : FAILED')
-endif
-
-message('git submodule update of ecmd : SUCCESS')
-
 build_arch = build_machine.cpu()
 host_arch = host_machine.cpu()
 message('Build target: ' + build_arch)


### PR DESCRIPTION
The git init and update command when part of meson fails while the recipe is built using bitbake. So removed the git init and update commands and let the recipe pull the ecmd repo as part of ecmd-pdbg

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>