### PR TITLE
ecmd-pdbg: Fix getscom to handle target not enabled

### DIFF
--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -987,20 +987,13 @@ uint32_t addChipUnits(const ecmdChipTarget & i_target, struct pdbg_target *i_pTa
         (cuString != i_target.chipUnitType))
         continue;
       
-      // If i_allowDisabled isn't true, make sure it's not disabled
-      // check HWAS state to populate the table with only 
-      // functional resources
-      // Generally, if we don't add a check for the functional state then, 
-      // all the targets in the device tree will be marked as available even though
-      // they are functionally not enabled based on the HW config.
-      // Checking for the Functional state of a target based on the device tree 
-      // attribute HWAS_STATE as this attribute value will get populated from MRW 
-      // which can be treated as the correct state for the given target. 
-      if (!i_allowDisabled  && !isFunctionalTarget(target))
-        continue;
-
       //probe only the functional targets 
       pdbg_target_probe(target);
+      
+      // If i_allowDisabled isn't true, make sure it's not disabled
+      if ( (!i_allowDisabled)
+         && (pdbg_target_status(target) != PDBG_TARGET_ENABLED) )
+           continue;
 
       uint32_t chipUnitNum = getChipUnitPos(target);
     

--- a/src/p10/p10_edbgEcmdDllScom.C
+++ b/src/p10/p10_edbgEcmdDllScom.C
@@ -171,7 +171,7 @@ uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomDat
 
 uint32_t p10_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data) {
   uint32_t rc = ECMD_SUCCESS;
-  uint64_t data;
+  uint64_t data = 0;
   struct pdbg_target *target, *proc,*ocmb;
   struct pdbg_target *addr_base;
   std::string pdbgClassString;


### PR DESCRIPTION
getscom pu.perv 000F0040 -p0 -call

When the target is not enabled, the above getscom command used to list the targets that are not enabled and display junk values

That is addressed in this commit.

Test output:
bmc:~# getscom pu.perv 000F0040 -p0 -call
pu.perv k0:n0:s0:p00:c2    0x9C201C0000000000
pu.perv k0:n0:s0:p00:c3    0x9C201C0000000000
pu.perv k0:n0:s0:p00:c8    0x8020000100000000
pu.perv k0:n0:s0:p00:c9    0x8020000100000000
pu.perv k0:n0:s0:p00:c12   0xA020000100000000
pu.perv k0:n0:s0:p00:c13   0xA020000100000000
pu.perv k0:n0:s0:p00:c16   0x9C20000000000000
pu.perv k0:n0:s0:p00:c17   0x9C20000000000000
pu.perv k0:n0:s0:p00:c18   0x9C20000000000000
pu.perv k0:n0:s0:p00:c19   0x9C20000000000000
pu.perv k0:n0:s0:p00:c26   0xA020000100000000
pu.perv k0:n0:s0:p00:c27   0xA020000100000000
pu.perv k0:n0:s0:p00:c28   0xA020000100000000
pu.perv k0:n0:s0:p00:c30   0xA020000100000000
pu.perv k0:n0:s0:p00:c31   0xA020000100000000
pu.perv k0:n0:s0:p00:c32   0xBC20000000000000
pu.perv k0:n0:s0:p00:c33   0xBC20000000000000
pu.perv k0:n0:s0:p00:c34   0xBC20000000000000
pu.perv k0:n0:s0:p00:c35   0xBC20000000000000
pu.perv k0:n0:s0:p00:c36   0xBC20000000000000
pu.perv k0:n0:s0:p00:c37   0xBC20000000000000
pu.perv k0:n0:s0:p00:c38   0xBC20000000000000
pu.perv k0:n0:s0:p00:c39   0xBC20000000000000
/usr/bin/edbg getscom pu.perv 000F0040 -p0 -call

bmc:~# getscom pu.perv 000F0040 -p0 -c24
ERROR: (ECMD): getscom - Unable to find a valid chip to execute command on ERROR: (ECMD): ecmd - 'getscom' returned with error code 0x100100F (ERROR OPENING DECODE FILE)
/usr/bin/edbg getscom pu.perv 000F0040 -p0 -c24

bmc:~# getscom pu.perv 000F0040 -p0 -call | grep c24

bmc:~# getscom pu.perv 000F0040 -pall -c24..31 | grep c24 /usr/bin/edbg getscom pu.perv 000F0040 -pall -c24..31

bmc:~# getscom pu.perv 000F0040 -p0 -c34
pu.perv k0:n0:s0:p00:c34   0xBC20000000000000
/usr/bin/edbg getscom pu.perv 000F0040 -p0 -c34

bmc:~# getscom pu.perv 000F0040 -pall -c24..34 | grep c34
pu.perv k0:n0:s0:p00:c34   0xBC20000000000000

bmc:~# getscom pu.perv 000F0040 -pall -call | grep c34
pu.perv k0:n0:s0:p00:c34   0xBC20000000000000

The below -exist command gives 0 as value for targets that are not enabled bmc:~# getscom pu.perv 000F0040 -p0 -call -exist
pu.perv k0:n0:s0:p00:c1    0x0000000000000000
pu.perv k0:n0:s0:p00:c2    0x9C201C0000000000
pu.perv k0:n0:s0:p00:c3    0x9C201C0000000000
pu.perv k0:n0:s0:p00:c8    0x8020000100000000
pu.perv k0:n0:s0:p00:c9    0x8020000100000000
pu.perv k0:n0:s0:p00:c12   0xA020000100000000
pu.perv k0:n0:s0:p00:c13   0xA020000100000000
pu.perv k0:n0:s0:p00:c14   0x0000000000000000
pu.perv k0:n0:s0:p00:c15   0x0000000000000000
pu.perv k0:n0:s0:p00:c16   0x9C20000000000000
pu.perv k0:n0:s0:p00:c17   0x9C20000000000000
pu.perv k0:n0:s0:p00:c18   0x9C20000000000000
pu.perv k0:n0:s0:p00:c19   0x9C20000000000000
pu.perv k0:n0:s0:p00:c24   0x0000000000000000
pu.perv k0:n0:s0:p00:c25   0x0000000000000000
pu.perv k0:n0:s0:p00:c26   0xA020000100000000
pu.perv k0:n0:s0:p00:c27   0xA020000100000000
pu.perv k0:n0:s0:p00:c28   0xA020000100000000
pu.perv k0:n0:s0:p00:c29   0x0000000000000000
pu.perv k0:n0:s0:p00:c30   0xA020000100000000
pu.perv k0:n0:s0:p00:c31   0xA020000100000000
pu.perv k0:n0:s0:p00:c32   0xBC20000000000000
pu.perv k0:n0:s0:p00:c33   0xBC20000000000000
pu.perv k0:n0:s0:p00:c34   0xBC20000000000000
pu.perv k0:n0:s0:p00:c35   0xBC20000000000000
pu.perv k0:n0:s0:p00:c36   0xBC20000000000000
pu.perv k0:n0:s0:p00:c37   0xBC20000000000000
pu.perv k0:n0:s0:p00:c38   0xBC20000000000000
pu.perv k0:n0:s0:p00:c39   0xBC20000000000000
/usr/bin/edbg getscom pu.perv 000F0040 -p0 -call -exist