### PR TITLE
Fix omic getscom

### DIFF
--- a/src/p10/ekb/p10_scom_addr.C
+++ b/src/p10/ekb/p10_scom_addr.C
@@ -797,15 +797,7 @@ extern "C"
             if ( (getIoGroupAddr() == 0x2 ) ||
                  (getIoGroupAddr() == 0x3 ) )
             {
-                // Reg address must start with 1xxx (per group),
-                // excluding 1111 (per bus)
-                uint32_t regAddr = getIoRegAddr();
-
-                if ( ( ( regAddr & 0x1E0 ) != 0x1E0 ) &&
-                     ( ( regAddr & 0x100 ) == 0x100 ) )
-                {
-                    l_omicTarget = true;
-                }
+                l_omicTarget = true;
             }
         }
 
@@ -815,13 +807,10 @@ extern "C"
              ( getEndpoint() == PSCOM_ENDPOINT )  &&   // 0x1
              ( getRingId() >= OMI0_RING_ID )      &&   // 0x5
              ( getRingId() <= OMI1_RING_ID )      &&   // 0x6
-             ( getSatId()  == MC_SAT_ID0 )        &&   // 0x0 (DL)
-             ( getSatOffset() >= 0 )              &&   // shared regs 0-15
-             ( getSatOffset() <= 15 ) )
+             ( getSatId()  == MC_SAT_ID0 ) )           // 0x0 (DL)
         {
             l_omicTarget = true;
         }
-
         return l_omicTarget;
     }
 


### PR DESCRIPTION
The latest ekb code does not look for the address's getSatOffset() to be less
than 16.

The getSatOffset information is the bit0 to bit31 of the address
provided. The omic addresses fall outside that range.

Fix:
Mirroed the isOmictarget() method from the ekb and it fixed the issue.

Test Results:

getscom pu.omic 0C011422 -all
pu.omic k0:n0:s0:p00:c1    0x0000FF5100040020
pu.omic k0:n0:s0:p02:c1    0x0000FF5100040020
/usr/bin/edbg getscom pu.omic 0C011422 -all
p10bmc:/tmp# pdbg -P omic getscom 0x0C011422
p0: 0x000000000c011422 = 0x0000000000000000 (/proc0/pib/perv12/mc0/omic0)
p0: 0x000000000c011822 = 0x0000ff5100040020 (/proc0/pib/perv12/mc0/omic1)
p2: 0x000000000c011422 = 0x0000000000000000 (/proc2/pib/perv12/mc0/omic0)
p2: 0x000000000c011822 = 0x0000ff5100040020 (/proc2/pib/perv12/mc0/omic1)

p10bmc:/tmp# getscom pu.omic 0C011421 -all
pu.omic k0:n0:s0:p00:c1    0x050005000000006F
pu.omic k0:n0:s0:p02:c1    0x050005000000006F
/usr/bin/edbg getscom pu.omic 0C011421 -all
p10bmc:/tmp# pdbg -P omic getscom 0x0C011421
p0: 0x000000000c011421 = 0x0000000000000000 (/proc0/pib/perv12/mc0/omic0)
p0: 0x000000000c011821 = 0x050005000000006f (/proc0/pib/perv12/mc0/omic1)
p2: 0x000000000c011421 = 0x0000000000000000 (/proc2/pib/perv12/mc0/omic0)
p2: 0x000000000c011821 = 0x050005000000006f (/proc2/pib/perv12/mc0/omic1)

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>
