### PR TITLE
Fix istep(16.3) that was named incorrectly

### DIFF
--- a/src/istep/edbgIstep.C
+++ b/src/istep/edbgIstep.C
@@ -218,7 +218,7 @@ const edbgIPLTable::edbgIStep_t edbgIPLTable::cv_edbgIStepTable[] =
   {15,   4,                    "host_start_stop_engine",                   EDBG_ISTEP_HOST},
   {16,   1,                   "host_activate_boot_core",                   EDBG_ISTEP_HOST},
   {16,   2,             "host_activate_secondary_cores",                   EDBG_ISTEP_HOST},
-  {16,   3,                           "host_secure_rng",                   EDBG_ISTEP_HOST},
+  {16,   3,                      "host_secure_rng_noop",                   EDBG_ISTEP_HOST},
   {16,   4,                                 "mss_scrub",                   EDBG_ISTEP_HOST},
   {16,   5,                         "host_ipl_complete",                   EDBG_ISTEP_HOST},
   {17,   1,                           "collect_drawers",                   EDBG_ISTEP_NOOP},

--- a/src/istep/p10/help/istep_list.htxt
+++ b/src/istep/p10/help/istep_list.htxt
@@ -184,7 +184,7 @@ host_start_stop_engine                   15     Initialize the STOPGPE engine an
 
 host_activate_boot_core                  16     Activate boot core
 host_activate_secondary_cores            16     Activate secondary cores
-host_secure_rng                          16     Secure the random number
+No-op                                    16     
 mss_scrub                                16     Start background scrub
 host_ipl_complete                        16     Notify SP drawer ipl complete
 


### PR DESCRIPTION
The istep 16.3 performs "No-op" but is marked as "host_secure_rng" in istep list.so changing it to "No-op".

Before:
``` host_activate_boot_core                  16     Activate boot core
	host_activate_secondary_cores            16     Activate secondary cores
	host_secure_rng                          16     Secure the random number  --> Marked Incorrectly
	mss_scrub                                16     Start background scrub
	host_ipl_complete                        16     Notify SP drawer ipl complete
```

After:
```host_activate_boot_core                  16     Activate boot core
	host_activate_secondary_cores            16     Activate secondary cores
	No-op                                    16                               --> changed to No-op
	mss_scrub                                16     Start background scrub
	host_ipl_complete                        16     Notify SP drawer ipl complete
```

Change-Id: I71d0b9f03bfdfeb97fed5bc79e25b7e7f9ad6bdf
Signed-off-by: Parasa Swetha <Parasa.Swetha1@ibm.com>