### PR TITLE
Odyssey SCOM support

### DIFF
--- a/src/common/edbgCommon.C
+++ b/src/common/edbgCommon.C
@@ -99,3 +99,24 @@ uint8_t getFapiUnitPos(pdbg_target *target)
 
     return fapiUnitPos;
 }
+
+bool isOdysseyChip(pdbg_target *target)
+{
+    constexpr uint8_t ODYSSEY_CHIP_TYPE = 0x4B;
+    constexpr uint16_t ODYSSEY_CHIP_ID = 0x60C0;
+    
+    uint32_t chipID; //chip ID
+    if(!pdbg_target_get_attribute(target, "ATTR_CHIP_ID", 4, 1, &chipID)){ 
+       return out.error(EDBG_GENERAL_ERROR, FUNCNAME, 
+                 "ATTR_CHIP_ID Attribute get failed");
+    }
+    uint8_t chipType;
+    //size: uint8 => 1, uint16 => 2. uint32 => 4 uint64=> 8
+    if(!pdbg_target_get_attribute(target, "ATTR_TYPE", 1, 1, &chipType)){ 
+       return out.error(EDBG_GENERAL_ERROR, FUNCNAME, 
+                 "ATTR_TYPE Attribute get failed");
+    }
+    //both chipid and type shall match for it to return true
+    return( (chipID == ODYSSEY_CHIP_ID) && 
+        (chipType == ODYSSEY_CHIP_TYPE) );
+}

--- a/src/common/edbgCommon.H
+++ b/src/common/edbgCommon.H
@@ -60,5 +60,9 @@ uint32_t  probeChildTarget(struct pdbg_target *i_target,
 /* --------------------------------------- */
 uint8_t getFapiUnitPos(pdbg_target *target);
 
+/* --------------------------------------- */
+/* Return true if the given target is of Odyssey Chip*/
+/* --------------------------------------- */
+bool isOdysseyChip(pdbg_target *target);
 
 #endif /* edbgCommon_H */

--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -907,10 +907,11 @@ uint32_t queryConfigExistChips(const ecmdChipTarget & i_target, std::list<ecmdCh
     // Save what we got from recursing down, or just being happy at this level
     o_chipData.push_back(chipData);
   }
-  
-  //Show up explorer only if the explorer scoms are requested
-  if ((i_target.chipType == "explorer") ||
-      (i_target.chipTypeState == ECMD_TARGET_FIELD_WILDCARD))
+
+  //Show up explorer/odyssey only if the respective scoms are requested 
+  if ((i_target.chipType == "explorer") || (i_target.chipType == "odyssey") ||
+      (i_target.chipTypeState == ECMD_TARGET_FIELD_WILDCARD) || 
+      (i_target.chipType == "ody") || (i_target.chipType == "ocmb"))
   {
       //Next, Fill in explorer targets
       pdbg_for_each_class_target("ocmb", ocmbTarget) {
@@ -932,16 +933,26 @@ uint32_t queryConfigExistChips(const ecmdChipTarget & i_target, std::list<ecmdCh
           if (pdbg_target_status(ocmbTarget) != PDBG_TARGET_ENABLED)
       	    continue;
         }
-
+        
         // We passed our checks, load up our data
         chipData.chipUnitData.clear();
-        chipData.chipType = "explorer";
-        chipData.chipShortType = "exp";
-
+        
+        if(isOdysseyChip(ocmbTarget))
+        {
+          chipData.chipType = "odyssey";
+          chipData.chipShortType = "ody";
+        }
+        else
+        {
+          chipData.chipType = "explorer";
+          chipData.chipShortType = "exp";
+        }
         // Getting the seq id of the chip
         // We use FAPI unit position instead of Chip unit position here.
         // DDIMM populated position comes from TARGETING::ATTR_FAPI_POS
-        chipData.pos = getFapiUnitPos(ocmbTarget);
+        chipData.pos = getFapiUnitPos(ocmbTarget); //DB: which attr to look for odyssey
+
+        struct pdbg_target* childTarget;
 
         // If the chipUnitType states are set, see what chipUnitTypes are in this chipType
         if (i_target.chipUnitTypeState == ECMD_TARGET_FIELD_VALID
@@ -964,18 +975,16 @@ uint32_t addChipUnits(const ecmdChipTarget & i_target, struct pdbg_target *i_pTa
   ecmdChipUnitData chipUnitData;
   std::string cuString;
   ecmdChipTarget o_target;
-
-  p10x_convertPDBGClassString_to_CUString(class_name, cuString);
-  if (rc) return rc;
- 
+  
   if (class_name == "explorer")  {
     chipUnitData.chipUnitType = "mp";
     chipUnitData.chipUnitShortType = "mp";
     chipUnitData.chipUnitNum = 0;
     o_chipUnitData.push_back(chipUnitData);
   } else {
+    rc = p10x_convertPDBGClassString_to_CUString(class_name, cuString);
     pdbg_for_each_target(class_name.c_str(), i_pTarget, target) {
- 
+
       //If posState is set to VALID, check that our values match
       //If posState is set to WILDCARD, we don't care
       if ((i_target.chipUnitNumState == ECMD_TARGET_FIELD_VALID) &&
@@ -1024,37 +1033,100 @@ uint32_t addChipUnits(const ecmdChipTarget & i_target, struct pdbg_target *i_pTa
   return rc;
 }
 
+uint32_t addOdysseyChipUnits(const ecmdChipTarget & i_target, struct pdbg_target *i_pTarget, std::string class_name, std::list<ecmdChipUnitData> & o_chipUnitData, ecmdQueryDetail_t i_detail, bool i_allowDisabled)
+{
+  uint32_t rc = ECMD_SUCCESS;
+  ecmdChipUnitData chipUnitData;
+  struct pdbg_target *target;
+  std::string cuString;
+  ecmdChipTarget o_target;
+  
+  rc = odyssey_convertPDBGClassString_to_CUString(class_name, cuString);
+
+  pdbg_for_each_target(class_name.c_str(), i_pTarget, target) {
+    //If posState is set to VALID, check that our values match
+    //If posState is set to WILDCARD, we don't care
+    if ((i_target.chipUnitNumState == ECMD_TARGET_FIELD_VALID) &&
+      (pdbg_target_index(target) != i_target.chipUnitNum))
+        continue;
+    if ((i_target.chipUnitTypeState == ECMD_TARGET_FIELD_VALID) &&
+      (cuString != i_target.chipUnitType))
+        continue;
+    // Check for the next target, if the current one is 
+    // not functional and we do not allow disabled
+    if (!i_allowDisabled  && !isFunctionalTarget(target))
+    {
+      continue;
+    }
+    //probe only the functional targets 
+    pdbg_target_probe(target);
+    //A target could be functional and disabled. The disabled targets shall 
+    // NOT be scommed.
+    if(pdbg_target_status(target) != PDBG_TARGET_ENABLED)
+    {
+      continue;
+    }
+    uint32_t chipUnitNum = pdbg_target_index(target);
+    if (chipUnitNum >= 0) {
+      chipUnitData.threadData.clear();
+      chipUnitData.chipUnitType = cuString; 
+      chipUnitData.chipUnitNum = chipUnitNum;
+    }
+  
+    o_chipUnitData.push_back(chipUnitData);
+  }
+  return rc;
+}
+
 uint32_t queryConfigExistChipUnits(const ecmdChipTarget & i_target, struct pdbg_target * i_pTarget, std::string class_type, std::list<ecmdChipUnitData> & o_chipUnitData, ecmdQueryDetail_t i_detail, bool i_allowDisabled)  {
 
   uint32_t rc = ECMD_SUCCESS;
   ecmdChipUnitData chipUnitData;
   struct pdbg_target *target;
   uint32_t l_index;
-
   if(pdbg_get_proc() == PDBG_PROC_P10)
   {
-      for (l_index = 0;
+      if(class_type == "pu")
+      {
+        for (l_index = 0;
            l_index < (sizeof(ChipUnitTable) / sizeof(p10_chipUnit_t));
            l_index++)
-      {
-          // If pdbg class type is pib , don't add the chip unit to the
-          // queryConfigExistChipUnits
-          if (ChipUnitTable[l_index].pdbgClassType != "pib") {
-              rc = addChipUnits(i_target, i_pTarget, ChipUnitTable[l_index].pdbgClassType, 
-                                o_chipUnitData, i_detail, i_allowDisabled);
-              if (rc) {
-                  out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Failed to add chip unit:%s\n",
-                            ChipUnitTable[l_index].pdbgClassType.c_str());
-              }
-          }
+        {
+            // If pdbg class type is pib , don't add the chip unit to the
+            // queryConfigExistChipUnits
+            if (ChipUnitTable[l_index].pdbgClassType != "pib") {
+                rc = addChipUnits(i_target, i_pTarget, ChipUnitTable[l_index].pdbgClassType, 
+                                  o_chipUnitData, i_detail, i_allowDisabled);
+                if (rc) {
+                    out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Failed to add chip unit:%s\n",
+                              ChipUnitTable[l_index].pdbgClassType.c_str());
+                }
+            }
+        }
       }
       //Add explorer targets if target class type selected is explorer
-      if (class_type == "explorer")
+      else if (class_type == "explorer")
       {
           rc = addChipUnits(i_target, i_pTarget, class_type, 
                             o_chipUnitData, i_detail, i_allowDisabled);
           if (rc) {
               return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Failed to add ocmb chip unit\n");
+          }
+      }      
+      else if(class_type == "odyssey")
+      {
+        for (l_index = 0;
+          l_index < (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t));
+          l_index++)
+          {
+            if (OdysseyChipUnitTable[l_index].pdbgClassType != "pib") {
+                rc = addOdysseyChipUnits(i_target, i_pTarget, OdysseyChipUnitTable[l_index].pdbgClassType, 
+                                  o_chipUnitData, i_detail, i_allowDisabled);
+                if (rc) {
+                    out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Failed to add chip unit:%s\n",
+                              OdysseyChipUnitTable[l_index].pdbgClassType.c_str());
+                }
+            }
           }
       }
   }
@@ -1273,7 +1345,6 @@ uint32_t dllGetChipData(const ecmdChipTarget & i_target, ecmdChipData & o_data) 
      
       //chipEC is 0 if we fail to read via attribute
       uint8_t chipEC = 0;
-
       pdbg_for_each_class_target("proc", chipTarget) {
 
         index = pdbg_target_index(chipTarget);

--- a/src/p10/p10_edbgEcmdDllScom.C
+++ b/src/p10/p10_edbgEcmdDllScom.C
@@ -108,7 +108,102 @@ uint32_t p10x_convertPDBGClassString_to_CUString(std::string pdbgClassType, std:
   return rc;
 }
 
-uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail) {
+
+uint32_t odyssey_convertCUEnum_to_String(odysseyChipUnits_t i_odysseyCU, std::string &o_chipUnitType)
+{
+  uint32_t rc = ECMD_SUCCESS;
+  uint32_t l_index;
+
+  for (l_index = 0;
+       l_index < (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t));
+       l_index++)
+  {
+      //Looking for input ekb chip unit in table
+      if (i_odysseyCU == OdysseyChipUnitTable[l_index].ekbChipUnit)
+          break;
+
+  }
+  // Can't find i_odysseyCU in table
+  if (l_index >= (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t))){
+      return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit enum:%d\n", i_odysseyCU);
+  }
+  o_chipUnitType = OdysseyChipUnitTable[l_index].chipUnitType;
+  return rc;
+}
+
+//convert chipunit string to pdbg class type, as pdbg does not accept ecmd strings
+uint32_t odyssey_convertCUString_to_pdbgClassString(std::string cuString, std::string &o_pdbgClassType)
+{
+  uint32_t rc = ECMD_SUCCESS;
+  uint32_t l_index;
+
+  for (l_index = 0;
+       l_index < (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t));
+       l_index++)
+  {
+      //Looking for input chip unit type in table
+      if (cuString == OdysseyChipUnitTable[l_index].chipUnitType)
+          break;
+
+  }
+  // Can't find cuString in table
+  if (l_index >= (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t))){
+      return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit:%S\n", cuString.c_str());
+  }
+
+  o_pdbgClassType = OdysseyChipUnitTable[l_index].pdbgClassType;
+  return rc;
+}
+
+//convert chipunit string to pdbg class type, as pdbg does not accept ecmd strings
+uint32_t odyssey_convertPDBGClassString_to_CUString(std::string pdbgClassType, std::string &o_chipUnitType) {
+
+  uint32_t rc = ECMD_SUCCESS;
+  uint32_t l_index;
+
+  for (l_index = 0;
+       l_index < (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t));
+       l_index++)
+  {
+      //Looking for input chip unit type in table
+      if (pdbgClassType == OdysseyChipUnitTable[l_index].pdbgClassType)
+          break;
+
+  }
+  // Can't find pdbgClassType in table
+  if (l_index >= (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t))){
+      return  out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown pdbg class unit:%s\n", pdbgClassType.c_str());
+  }
+
+  o_chipUnitType = OdysseyChipUnitTable[l_index].chipUnitType;
+  return rc;
+}
+
+//convert chipunit string to ekb chip unit
+uint32_t odyssey_convertCUString_to_CUEnum(std::string i_chipUnitType, odysseyChipUnits_t o_odysseyCU) {
+
+  uint32_t rc = ECMD_SUCCESS;
+  uint32_t l_index;
+
+  for (l_index = 0;
+       l_index < (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t));
+       l_index++)
+  {
+      //Looking for input ekb chip unit in table
+      if (i_chipUnitType == OdysseyChipUnitTable[l_index].chipUnitType)
+          break;
+
+  }
+  // Can't find i_odysseyCU in table
+  if (l_index >= (sizeof(OdysseyChipUnitTable) / sizeof(odyssey_chipUnit_t))){
+      return out.error(EDBG_GENERAL_ERROR, FUNCNAME, "Unknown chip unit string:%s\n", i_chipUnitType);
+  }
+  o_odysseyCU = OdysseyChipUnitTable[l_index].ekbChipUnit;
+  return rc;
+}
+
+uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail) 
+{
   uint32_t rc = ECMD_SUCCESS;
   ecmdScomData sdReturn;
 
@@ -124,8 +219,6 @@ uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomDat
           return out.error(rc, FUNCNAME,  "dllGetChipData() returned error");
       }
 
-      //sdReturn.address = i_address;
-      //sdReturn.length = 64;
       sdReturn.isChipUnitRelated = false;
       sdReturn.endianMode = ECMD_BIG_ENDIAN;
       std::vector<p10_chipUnitPairing_t> l_chipUnitPairing;
@@ -160,33 +253,109 @@ uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomDat
     sdReturn.isChipUnitRelated = true;
     sdReturn.relatedChipUnit.push_back("mp");
     sdReturn.relatedChipUnitShort.push_back("mp");
-  } //End chip type check
 
-  sdReturn.address = i_address;
+  } else if ( (i_target.chipType == "odyssey") ||
+            (i_target.chipType == "ody") ) {
+    
+    ecmdChipData l_chipData;
+    rc = dllGetChipData(i_target,l_chipData);
+    if (rc != ECMD_SUCCESS) {
+        return out.error(rc, FUNCNAME,  "dllGetChipData() returned error");
+    }
+
+    sdReturn.isChipUnitRelated = false;
+    sdReturn.endianMode = ECMD_BIG_ENDIAN;
+    std::vector<odyssey_chipUnitPairing_t> l_chipUnitPairing;
+    sdReturn.relatedChipUnit.clear();
+    sdReturn.relatedChipUnitShort.clear();
+
+    ///< ODYSSEY chip and no chipunit - unused in the below function
+    odysseyChipUnits_t i_odysseyCU = ODYSSEY_NO_CU; 
+    
+    rc = odyssey_scominfo_isChipUnitScom(i_odysseyCU, l_chipData.chipEc, i_address, 
+    sdReturn.isChipUnitRelated, l_chipUnitPairing);
+
+    if (sdReturn.isChipUnitRelated) {
+        std::vector<odyssey_chipUnitPairing_t>::const_iterator cuPairingIter = l_chipUnitPairing.begin();
+
+    while(cuPairingIter != l_chipUnitPairing.end()) {
+            std::string l_chipUnitType;
+            rc = odyssey_convertCUEnum_to_String(cuPairingIter->chipUnitType, l_chipUnitType);
+            if (rc) return rc;
+            sdReturn.isChipUnitRelated = true;
+            sdReturn.relatedChipUnit.push_back(l_chipUnitType);
+            sdReturn.relatedChipUnitShort.push_back(l_chipUnitType);
+            cuPairingIter++;
+        }
+    }
+    if (rc) 
+    {
+        return out.error(rc, FUNCNAME,"Invalid scom addr via scom address lookup via p10_scominfo_isChipUnitScom failed\n");
+    }
+  }
+
+  //End chip type check
   sdReturn.length = 64;
+  sdReturn.address = i_address;
   o_queryData.push_back(sdReturn);
-
   return rc;
 }
 
-uint32_t p10_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data) {
+uint32_t p10_dllGetScom(const ecmdChipTarget & input_target, uint64_t i_address, ecmdDataBuffer & o_data) {
+  ecmdChipTarget i_target = input_target;
   uint32_t rc = ECMD_SUCCESS;
   uint64_t data = 0;
-  struct pdbg_target *target, *proc,*ocmb;
+  struct pdbg_target *target, *proc, *ocmb;
   struct pdbg_target *addr_base;
   std::string pdbgClassString;
-
-  if(i_target.chipType == "explorer")
+  if(i_target.chipType == "odyssey")
+  {
+    rc = odyssey_convertCUString_to_pdbgClassString(i_target.chipUnitType, pdbgClassString);
+    //First in the parent ocmb, we need to look if it matches in the index given in the command
+    //Then we will go into the children of that ocmb for that specific target type
+    pdbg_for_each_class_target("ocmb", ocmb) 
+    {
+        //The target position didnt match ocmb fapi pos, so move on
+        if (getFapiUnitPos(ocmb) != i_target.pos)
+            continue;
+        if(pdbgClassString.empty()) //We are doing a getscom for the odyssey chip
+        {
+            rc = ocmb_getscom(ocmb, i_address, &data);
+            break; 
+        }
+        else // This is a chipunit getscom, so we need to call pib_ody_read
+        {
+            pdbg_for_each_target(pdbgClassString.c_str(), ocmb, target) 
+            {
+                if (i_target.chipUnitType != "")
+                {
+                if (pdbg_target_index(target) != i_target.chipUnitNum)
+                    continue;
+                }
+                // Make sure the pdbg target probe has been done and get the target state
+                if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED)
+                    continue; 
+                rc = pib_ody_read(target, i_address, &data); 
+                if (rc) 
+                {
+                    return out.error(EDBG_READ_ERROR, FUNCNAME,
+                            "ody_ocmb_getscom of 0x%016" PRIx64 " = 0x%016" PRIx64 " failed (%s), rc=%d \n",
+                            i_address, data, pdbg_target_path(ocmb),rc);
+                }
+                //we have read the address, break
+                break;
+            }
+        }
+    }
+  }
+  else if(i_target.chipType == "explorer")
   {
       pdbg_for_each_class_target("ocmb", ocmb) {
-   
           if (getFapiUnitPos(ocmb) != i_target.pos)
               continue;
-
           // Make sure the pdbg target probe has been done and get the target state
           if (pdbg_target_probe(ocmb) != PDBG_TARGET_ENABLED)
               continue;
-          
           rc = ocmb_getscom(ocmb, i_address, &data);
           if (rc) {
               return out.error(EDBG_READ_ERROR, FUNCNAME,

--- a/src/p10/p10_edbgEcmdDllScom.H
+++ b/src/p10/p10_edbgEcmdDllScom.H
@@ -23,6 +23,7 @@
 #define p10_edbgEcmdDllScom_H
 
 #include <p10_scominfo.H>
+#include <odyssey_scominfo.H>
 
 struct p10_chipUnit_t{
         p10ChipUnits_t ekbChipUnit;
@@ -55,6 +56,22 @@ const p10_chipUnit_t ChipUnitTable[] =
         { P10_NO_CU,        "smpgroup", "smpgroup"}, //Not a scommable target. leaving it NO_CU
 };
 
+
+struct odyssey_chipUnit_t{
+        odysseyChipUnits_t ekbChipUnit;
+	std::string chipUnitType;
+        std::string pdbgClassType;
+};
+
+//mapping table for ekb, ecmd and pdbg
+const odyssey_chipUnit_t OdysseyChipUnitTable[] =
+{
+        { ODYSSEY_NO_CU, "", "" },
+        { ODYSSEY_MEMPORT_CHIPUNIT, "mp",   "mem_port" },
+        { ODYSSEY_PERV_CHIPUNIT, "perv", "chiplet" },
+        { ODYSSEY_OMI_CHIPUNIT, "omi",  "omi"  },
+};
+
 uint32_t p10_dllQueryScom(const ecmdChipTarget & i_target, std::list<ecmdScomData> & o_queryData, uint64_t i_address, ecmdQueryDetail_t i_detail);
 
 uint32_t p10_dllGetScom(const ecmdChipTarget & i_target, uint64_t i_address, ecmdDataBuffer & o_data);
@@ -64,5 +81,17 @@ uint32_t p10_dllPutScom(const ecmdChipTarget & i_target, uint64_t i_address, con
 uint32_t p10_dllPutScomUnderMask(const ecmdChipTarget & i_target, uint64_t i_address, const ecmdDataBuffer & i_data, const ecmdDataBuffer & i_mask);
 
 uint32_t p10x_convertPDBGClassString_to_CUString(std::string pdbgClassType, std::string &o_chipUnitType);
+
+//convert ekb chip unit enum to ecmd chinpunit string
+uint32_t odyssey_convertCUEnum_to_String(odysseyChipUnits_t i_odysseyCU, std::string &o_chipUnitType);
+
+//convert ecmd chipunit string to pdbg class type, as pdbg does not accept ecmd strings
+uint32_t odyssey_convertCUString_to_pdbgClassString(std::string cuString, std::string &o_pdbgClassType);
+
+//convert emcd chipunit string to pdbg class type, as pdbg does not accept ecmd strings
+uint32_t odyssey_convertPDBGClassString_to_CUString(std::string pdbgClassType, std::string &o_chipUnitType);
+
+//convert ecmd chipunit string to ekb chip unit
+uint32_t odyssey_convertCUString_to_CUEnum(std::string i_chipUnitType, odysseyChipUnits_t o_odysseyCU);
 
 #endif


### PR DESCRIPTION
Added the changes to support odyssey chip and chipunits scom. Checks attribute chip-id of the ocmb target  to differentiate between ddr4 and ddr5 ocmb chips for get/put scom

Tested:
p10bmc:/tmp# getscom odyssey c0002040 -pall
odyssey k0:n0:s0:p02       0x0040010002000640
odyssey k0:n0:s0:p03       0x0040010002000640
odyssey k0:n0:s0:p34       0x0040010002000640
odyssey k0:n0:s0:p35       0x0040010002000640
/usr/bin/edbg getscom odyssey c0002040 -pall

p10bmc:/tmp# ecmdquery chips -dc
cage 0
  node 0
    slot 0
      pu
        p[0]
        ...
        ...
      odyssey
        p[2]
          mp[0,1]
          perv[8]
        p[3]
          mp[0,1]
          perv[8]
        p[34]
          mp[0,1]
          perv[8]
        p[35]
          mp[0,1]
          perv[8]
/usr/bin/edbg ecmdquery chips -dc