### PR TITLE
Use a unique class name for ody perv target

### DIFF
--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -1084,18 +1084,6 @@ uint32_t addChipUnits(const ecmdChipTarget &i_target,
     rc = p10x_convertPDBGClassString_to_CUString(class_name, cuString);
     pdbg_for_each_target(class_name.c_str(), i_pTarget, target) {
 
-      // If it is a chipunit, it could be under ocmb. So ignore it is
-      // under ocmb
-      if (class_name == "chiplet") {
-        std::string substring = "ocmb";
-        std::string targetPath = pdbg_target_path(target);
-        // the path contains ocmb, so this should not be considered as under
-        // proc
-        if (targetPath.find(substring) != std::string::npos) {
-          continue;
-        }
-      }
-
       // If posState is set to VALID, check that our values match
       // If posState is set to WILDCARD, we don't care
       if ((i_target.chipUnitNumState == ECMD_TARGET_FIELD_VALID) &&

--- a/src/p10/p10_edbgEcmdDllScom.H
+++ b/src/p10/p10_edbgEcmdDllScom.H
@@ -66,7 +66,7 @@ struct odyssey_chipUnit_t {
 const odyssey_chipUnit_t OdysseyChipUnitTable[] = {
     {ODYSSEY_NO_CU, "", ""},
     {ODYSSEY_MEMPORT_CHIPUNIT, "mp", "mem_port"},
-    {ODYSSEY_PERV_CHIPUNIT, "perv", "chiplet"},
+    {ODYSSEY_PERV_CHIPUNIT, "perv", "ody_chiplet"},
     {ODYSSEY_OMI_CHIPUNIT, "omi", "omi"},
 };
 


### PR DESCRIPTION
If the compatible property and the class name for both proc processor and odyssey processor is same, then we need to check everywhere if that is a chiplet under a proc or under a odyssey. Having a unique name solves the issue.