### PR TITLE
Use pdbg target index for ody targets

### DIFF
--- a/src/common/edbgCommon.C
+++ b/src/common/edbgCommon.C
@@ -85,17 +85,24 @@ uint32_t probeChildTarget(struct pdbg_target *i_pTarget,
   return 0;
 }
 
-uint8_t getFapiUnitPos(pdbg_target *target) {
-  uint32_t fapiUnitPos; // chip unit position
+uint8_t getIndexOrFapiPos(pdbg_target *target, std::string chipType) {
+  uint32_t pos; // chip unit position
 
   // size: uint8 => 1, uint16 => 2. uint32 => 4 uint64=> 8
   // typedef uint32_t ATTR_FAPI_POS_Type;
-  if (!pdbg_target_get_attribute(target, "ATTR_FAPI_POS", 4, 1, &fapiUnitPos)) {
-    return out.error(EDBG_GENERAL_ERROR, FUNCNAME,
-                     "ATTR_FAPI_POS Attribute get failed");
+  // If Ody, return pdbg index,
+  // for explorer chip, return the fapi pos
+  if ((chipType == "odyssey") || (chipType == "ody")) {
+    pos = pdbg_target_index(target);
+  } else {
+
+    if (!pdbg_target_get_attribute(target, "ATTR_FAPI_POS", 4, 1, &pos)) {
+      return out.error(EDBG_GENERAL_ERROR, FUNCNAME,
+                       "ATTR_FAPI_POS Attribute get failed");
+    }
   }
 
-  return fapiUnitPos;
+  return pos;
 }
 
 bool isOdysseyChip(pdbg_target *target) {

--- a/src/common/edbgCommon.H
+++ b/src/common/edbgCommon.H
@@ -60,7 +60,7 @@ uint32_t probeChildTarget(struct pdbg_target *i_target,
 /* --------------------------------------- */
 /* Get Fapi Unit Position for given target */
 /* --------------------------------------- */
-uint8_t getFapiUnitPos(pdbg_target *target);
+uint8_t getIndexOrFapiPos(pdbg_target *target, std::string chipType);
 
 /* --------------------------------------- */
 /* Return true if the given target is of Odyssey Chip*/

--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -1007,7 +1007,7 @@ uint32_t queryConfigExistChips(const ecmdChipTarget &i_target,
       // If posState is set to WILDCARD, we don't care
       if ((pdbg_target_index(ocmbTarget) < 0) ||
           ((i_target.posState == ECMD_TARGET_FIELD_VALID) &&
-           (getFapiUnitPos(ocmbTarget) != i_target.pos)))
+           (getIndexOrFapiPos(ocmbTarget, i_target.chipType) != i_target.pos)))
         continue;
 
       // Add to the data structure only if functional
@@ -1043,8 +1043,8 @@ uint32_t queryConfigExistChips(const ecmdChipTarget &i_target,
       // Getting the seq id of the chip
       // We use FAPI unit position instead of Chip unit position here.
       // DDIMM populated position comes from TARGETING::ATTR_FAPI_POS
-      chipData.pos =
-          getFapiUnitPos(ocmbTarget); // DB: which attr to look for odyssey
+      chipData.pos = getIndexOrFapiPos(
+          ocmbTarget, chipData.chipType); // DB: which attr to look for odyssey
 
       struct pdbg_target *childTarget;
 
@@ -1633,7 +1633,7 @@ uint32_t dllGetCfamRegister(const ecmdChipTarget &i_target, uint32_t i_address,
     pdbg_for_each_class_target("ocmb", ocmbTarget) {
       // If posState is set to VALID, check that our values match
       // If posState is set to WILDCARD, we don't care
-      if (getFapiUnitPos(ocmbTarget) != i_target.pos)
+      if (getIndexOrFapiPos(ocmbTarget, i_target.chipType) != i_target.pos)
         continue;
       pdbg_target_probe(ocmbTarget);
       if (pdbg_target_status(ocmbTarget) != PDBG_TARGET_ENABLED)
@@ -1669,7 +1669,7 @@ uint32_t dllPutCfamRegister(const ecmdChipTarget &i_target, uint32_t i_address,
     pdbg_for_each_class_target("ocmb", ocmbTarget) {
       // If posState is set to VALID, check that our values match
       // If posState is set to WILDCARD, we don't care
-      if (getFapiUnitPos(ocmbTarget) != i_target.pos)
+      if (getIndexOrFapiPos(ocmbTarget, i_target.chipType) != i_target.pos)
         continue;
       pdbg_target_probe(ocmbTarget);
       if (pdbg_target_status(ocmbTarget) != PDBG_TARGET_ENABLED)

--- a/src/p10/p10_edbgEcmdDllScom.C
+++ b/src/p10/p10_edbgEcmdDllScom.C
@@ -325,15 +325,15 @@ uint32_t p10_dllGetScom(const ecmdChipTarget &input_target, uint64_t i_address,
     // that specific target type
     pdbg_for_each_class_target("ocmb", ocmb) {
       // The target position didnt match ocmb fapi pos, so move on
-      if (getFapiUnitPos(ocmb) != i_target.pos)
+      if (getIndexOrFapiPos(ocmb, i_target.chipType) != i_target.pos) {
         continue;
+      }
       if (pdbgClassString
               .empty()) // We are doing a getscom for the odyssey chip
       {
         rc = ocmb_getscom(ocmb, i_address, &data);
         break;
-      } else
-      {
+      } else {
         pdbg_for_each_target(pdbgClassString.c_str(), ocmb, target) {
           if (i_target.chipUnitType != "") {
             if (pdbg_target_index(target) != i_target.chipUnitNum)
@@ -360,7 +360,7 @@ uint32_t p10_dllGetScom(const ecmdChipTarget &input_target, uint64_t i_address,
 
   else if (i_target.chipType == "explorer") {
     pdbg_for_each_class_target("ocmb", ocmb) {
-      if (getFapiUnitPos(ocmb) != i_target.pos)
+      if (getIndexOrFapiPos(ocmb, i_target.chipType) != i_target.pos)
         continue;
       // Make sure the pdbg target probe has been done and get the target state
       if (pdbg_target_probe(ocmb) != PDBG_TARGET_ENABLED)
@@ -444,7 +444,7 @@ uint32_t p10_dllPutScom(const ecmdChipTarget &i_target, uint64_t i_address,
     // that specific target type
     pdbg_for_each_class_target("ocmb", ocmb) {
       // The target position didnt match ocmb fapi pos, so move on
-      if (getFapiUnitPos(ocmb) != i_target.pos)
+      if (getIndexOrFapiPos(ocmb, i_target.chipType) != i_target.pos)
         continue;
       if (pdbgClassString
               .empty()) // We are doing a getscom for the odyssey chip
@@ -457,8 +457,7 @@ uint32_t p10_dllPutScom(const ecmdChipTarget &i_target, uint64_t i_address,
                            i_address, pdbg_target_path(ocmb), rc);
         }
         break;
-      } else
-      {
+      } else {
         pdbg_for_each_target(pdbgClassString.c_str(), ocmb, target) {
           if (i_target.chipUnitType != "") {
             if (pdbg_target_index(target) != i_target.chipUnitNum)
@@ -484,7 +483,7 @@ uint32_t p10_dllPutScom(const ecmdChipTarget &i_target, uint64_t i_address,
   } else if (i_target.chipType == "explorer") {
     pdbg_for_each_class_target("ocmb", ocmb) {
 
-      if (getFapiUnitPos(ocmb) != i_target.pos)
+      if (getIndexOrFapiPos(ocmb, i_target.chipType) != i_target.pos)
         continue;
 
       // Make sure the pdbg target probe has been done and get the target state


### PR DESCRIPTION
The explorer chips use fapi position to identify the targets. The odyssey chip uses target index with the recent change. Updating the code to support the same.