### PR TITLE
ecmd-pdbg: Upgrade to c++20

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'ecmd-pdbg',
     ['cpp','c'],
     default_options: [
-        'cpp_std=c++17',
+        'cpp_std=c++20',
         'default_library=shared',
     ],
     meson_version : '>= 0.51',

--- a/src/dll/edbgEcmdDll.C
+++ b/src/dll/edbgEcmdDll.C
@@ -39,6 +39,13 @@
 #include <unistd.h>
 #include <yaml.h>
 
+#include <hwaccess/hw_access_intf.H>
+#include <targeting/target_service.H>
+#include <targeting/predicates/predicateattrval.H>
+#include <targeting/target.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
+
 // Headers from eCMD
 #include <ecmdChipTargetCompare.H>
 #include <ecmdDataBuffer.H>
@@ -1644,20 +1651,34 @@ uint32_t dllGetCfamRegister(const ecmdChipTarget &i_target, uint32_t i_address,
       break;
     }
   } else {
-    rc = fetchCfamTarget(i_target, &pdbgTarget);
-    if (rc)
-      return rc;
+     try
+    {
+        using namespace TARGETING;
+        PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+        auto& ts = TargetService::instance();
+        ts.init("/tmp/targeting_test.dtb");
+        auto top = ts.getTopLevelTarget();
 
-    // Make sure the pdbg target probe has been done and get the target state
-    if (pdbg_target_probe(pdbgTarget) != PDBG_TARGET_ENABLED) {
-      return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME,
-                       "Target not configured!\n");
+        for (auto&& target :
+                 ts.getAssociated(top, AssociationType::childByPhysical,
+                                  RecursionLevel::all, &pred))
+        {
+            if (i_target.pos == target->getAttr<ATTR_FAPI_POS>())
+            {
+                ts.setHwAccessMethod(target, HW_ACCESS_METHOD_DIRECT_ACCESS);
+                rc = hwaccess::HwAccessIntf::getCfamRegister(target, i_address, data);
+                break;
+            }
+        }
     }
-    rc = fsi_read(pdbgTarget, i_address, &data);
+    catch (std::exception& ex)
+    {
+        std::cerr << "Exception: " << ex.what() << "\n";
+    }
   }
-  o_data.setBitLength(32);
-  o_data.setWord(0, data);
-  return rc;
+    o_data.setBitLength(32);
+    o_data.setWord(0, data);
+    return rc;
 }
 
 uint32_t dllPutCfamRegister(const ecmdChipTarget &i_target, uint32_t i_address,
@@ -1680,16 +1701,30 @@ uint32_t dllPutCfamRegister(const ecmdChipTarget &i_target, uint32_t i_address,
       break;
     }
   } else {
-    rc = fetchCfamTarget(i_target, &pdbgTarget);
-    if (rc)
-      return rc;
+     try
+    {
+        using namespace TARGETING;
+        PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+        auto& ts = TargetService::instance();
+        ts.init("/tmp/targeting_test.dtb");
+        auto top = ts.getTopLevelTarget();
 
-    // Make sure the pdbg target probe has been done and get the target state
-    if (pdbg_target_probe(pdbgTarget) != PDBG_TARGET_ENABLED) {
-      return out.error(ECMD_TARGET_NOT_CONFIGURED, FUNCNAME,
-                       "Target not configured!\n");
+        for (auto&& target :
+                 ts.getAssociated(top, AssociationType::childByPhysical,
+                                  RecursionLevel::all, &pred))
+        {
+            if (i_target.pos == target->getAttr<ATTR_FAPI_POS>())
+            {
+                ts.setHwAccessMethod(target, HW_ACCESS_METHOD_DIRECT_ACCESS);
+                rc = hwaccess::HwAccessIntf::putCfamRegister(target, i_address, i_data.getWord(0));
+                break;
+            }
+        }
     }
-    rc = fsi_write(pdbgTarget, i_address, i_data.getWord(0));
+    catch (std::exception& ex)
+    {
+        std::cerr << "Exception: " << ex.what() << "\n";
+    }
   }
   return rc;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,12 @@ if get_option('journal').enabled()
     libsystemd_pkg = dependency('libsystemd')
 endif
 
+dep_targeting = dependency('libtargeting', required: true)
+dep_hwaccess = dependency('libhwaccess', required: true)
+dep_targetsvc = dependency('libtargetsvc', required: true)
+dep_transport = dependency('libtransport', required: true)
+dep_fdt = dependency('libfdt-custom', required: true)
+
 libedbg = library(
             'edbg',
             'common/edbgCommon.C',
@@ -47,7 +53,9 @@ libedbg = library(
             '../ecmd/ecmd-core/dll/ecmdDllCapi.C',
             '../' + autogen_path + '/cipDllCapi.C',
             include_directories : headers,
-            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb, get_option('journal').enabled() ? libsystemd_pkg :[]],
+            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb,
+                            dep_targeting, dep_hwaccess, dep_targetsvc, dep_transport, dep_fdt,
+                            get_option('journal').enabled() ? libsystemd_pkg :[]],
             link_with : libecmd,
             version: meson.project_version(),
             install: true)


### PR DESCRIPTION
Incoming targeting libs that intend to replace pdbg are based on c++20, hence upgrading to c++20 to enable integration.